### PR TITLE
Switch to webui dir

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
@@ -58,11 +58,14 @@ public class ForwardedDevProcessor {
     public ForwardedDevServerBuildItem prepareDevService(
             QuinoaConfig quinoaConfig,
             LaunchModeBuildItem launchMode,
-            Optional<QuinoaDirectoryBuildItem> srcUIDir,
+            Optional<QuinoaDirectoryBuildItem> quinoaDir,
             BuildProducer<DevServicesResultBuildItem> devServices,
             Optional<ConsoleInstalledBuildItem> consoleInstalled,
             LoggingSetupBuildItem loggingSetup,
             CuratedApplicationShutdownBuildItem shutdown) {
+        if (!quinoaDir.isPresent()) {
+            return null;
+        }
         if (devService != null) {
             boolean shouldShutdownTheBroker = !quinoaConfig.equals(cfg);
             if (!shouldShutdownTheBroker) {
@@ -103,7 +106,7 @@ public class ForwardedDevProcessor {
                 loggingSetup,
                 PROCESS_THREAD_PREDICATE);
 
-        PackageManager packageManager = autoDetectPackageManager(quinoaConfig.packageManager, srcUIDir.get().getDirectory());
+        PackageManager packageManager = autoDetectPackageManager(quinoaConfig.packageManager, quinoaDir.get().getDirectory());
         final AtomicReference<Process> dev = new AtomicReference<>();
         try {
             final int devServerPort = quinoaConfig.devServerPort.getAsInt();

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaConfig.java
@@ -12,26 +12,24 @@ public class QuinoaConfig {
 
     /**
      * Indicate if the extension should be enabled
-     * Default is true if the UI directory exists and dev and prod mode
-     * Default is false in test mode (to avoid building the UI during backend tests)
+     * Default is true if the Web UI directory exists and dev and prod mode
+     * Default is false in test mode (to avoid building the Web UI during backend tests)
      */
     @ConfigItem(name = ConfigItem.PARENT)
     Optional<Boolean> enable;
 
     /**
-     * Path to the UI (node) root directory.
-     * If not set ${project.root}/src/main/ui/ will be used
-     * If set to an absolute path then the absolute path will be used, otherwise the path
-     * will be considered relative to the project root
+     * Path to the Web UI (node) root directory.
+     * If not set ${project.root}/src/main/webui/ will be used
+     * otherwise the path will be considered relative to the project root
      */
     @ConfigItem
     public Optional<String> uiDir;
 
     /**
-     * Path of the directory which contains the resulting ui built files.
+     * Path of the directory which contains the resulting Web UI built files.
      * If not set build/ will be used
-     * If set to an absolute path then the absolute path will be used, otherwise the path
-     * will be considered relative to the UI path
+     * otherwise the path will be considered relative to the Web UI path
      */
     @ConfigItem
     public Optional<String> buildDir;
@@ -45,8 +43,8 @@ public class QuinoaConfig {
     public Optional<String> packageManager;
 
     /**
-     * Indicate if the UI should also be tested during the build phase (i.e: npm test)
-     * To be used in a {@link io.quarkus.test.junit.QuarkusTestProfile} to have UI test running during a
+     * Indicate if the Web UI should also be tested during the build phase (i.e: npm test)
+     * To be used in a {@link io.quarkus.test.junit.QuarkusTestProfile} to have Web UI test running during a
      * {@link io.quarkus.test.junit.QuarkusTest}
      * Default is false
      */

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -50,6 +50,7 @@ public class QuinoaProcessor {
     private static final String FEATURE = "quinoa";
     private static final String TARGET_DIR_NAME = "quinoa-build";
     private static final Set<String> IGNORE_WATCH = Set.of("node_modules", "build", "target", "dist");
+    public static final String DEFAULT_WEB_UI_DIR = "src/main/webui";
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -221,7 +222,8 @@ public class QuinoaProcessor {
         if (mainSourcesRoot == null) {
             return null;
         }
-        Path uiRoot = mainSourcesRoot.getKey().resolve(quinoaConfig.uiDir.orElse("ui"));
+        final String uiDir = quinoaConfig.uiDir.orElse(DEFAULT_WEB_UI_DIR);
+        final Path uiRoot = mainSourcesRoot.getValue().resolve(uiDir);
         final File file = uiRoot.toFile();
         if (!file.exists() || !file.isDirectory()) {
             return null;

--- a/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
@@ -12,7 +12,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa]]`link:#q
 
 [.description]
 --
-Indicate if the extension should be enabled Default is true if the UI directory exists and dev and prod mode Default is false in test mode (to avoid building the UI during backend tests)
+Indicate if the extension should be enabled Default is true if the Web UI directory exists and dev and prod mode Default is false in test mode (to avoid building the Web UI during backend tests)
 --|boolean 
 |
 
@@ -21,7 +21,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.ui-dir]]`
 
 [.description]
 --
-Path to the UI (node) root directory. If not set $++{++project.root++}++/src/main/ui/ will be used If set to an absolute path then the absolute path will be used, otherwise the path will be considered relative to the project root
+Path to the Web UI (node) root directory. If not set $++{++project.root++}++/src/main/webui/ will be used otherwise the path will be considered relative to the project root
 --|string 
 |
 
@@ -30,7 +30,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.build-dir
 
 [.description]
 --
-Path of the directory which contains the resulting ui built files. If not set build/ will be used If set to an absolute path then the absolute path will be used, otherwise the path will be considered relative to the UI path
+Path of the directory which contains the resulting Web UI built files. If not set build/ will be used otherwise the path will be considered relative to the Web UI path
 --|string 
 |
 
@@ -48,7 +48,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.run-tests
 
 [.description]
 --
-Indicate if the UI should also be tested during the build phase (i.e: npm test) To be used in a `io.quarkus.test.junit.QuarkusTestProfile` to have UI test running during a `io.quarkus.test.junit.QuarkusTest` Default is false
+Indicate if the Web UI should also be tested during the build phase (i.e: npm test) To be used in a `io.quarkus.test.junit.QuarkusTestProfile` to have Web UI test running during a `io.quarkus.test.junit.QuarkusTest` Default is false
 --|boolean 
 |
 

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,19 +1,19 @@
-quarkus.quinoa.ui-dir=ui-react
+quarkus.quinoa.ui-dir=src/main/ui-react
 quarkus.http.header.Pragma.value=no-cache
 quarkus.http.header.Pragma.path=/headers/pragma
 quarkus.http.header.Pragma.methods=GET,HEAD
-%vue.quarkus.quinoa.ui-dir=ui-vue
+%vue.quarkus.quinoa.ui-dir=src/main/ui-vue
 %vue.quarkus.quinoa.build-dir=dist
-%angular.quarkus.quinoa.ui-dir=ui-angular
+%angular.quarkus.quinoa.ui-dir=src/main/ui-angular
 %angular.quarkus.quinoa.build-dir=dist/quinoa-app
-%lit.quarkus.quinoa.ui-dir=ui-lit
+%lit.quarkus.quinoa.ui-dir=src/main/ui-lit
 %lit.quarkus.quinoa.build-dir=dist
 %yarn.quarkus.quinoa.package-manager=yarn
 
 %angular-dev.quarkus.quinoa.dev-server-port=4200
-%angular-dev.quarkus.quinoa.ui-dir=ui-angular
+%angular-dev.quarkus.quinoa.ui-dir=src/main/ui-angular
 %angular-dev.quarkus.quinoa.build-dir=dist/quinoa-app
 %react-dev.quarkus.quinoa.dev-server-port=3000
 %vue-dev.quarkus.quinoa.dev-server-port=3000
-%vue-dev.quarkus.quinoa.ui-dir=ui-vue
+%vue-dev.quarkus.quinoa.ui-dir=src/main/ui-vue
 %vue-dev.quarkus.quinoa.build-dir=dist/


### PR DESCRIPTION
Fixes #26 

The default is now:
```properties
quarkus.quinoa.ui-dir=src/main/webui
```

The path is now relative to the project root as stated in the doc.