### PR TITLE
Make routing more consistent

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
@@ -75,8 +75,17 @@ a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.enable-sp
 
 [.description]
 --
-Enable SPA (Single Page Application) routing, all unhandled requests will be re-routed to the index.html If not set, it is disabled.
+Enable SPA (Single Page Application) routing, all relevant requests will be re-routed to the index.html Currently, for technical reasons, the Quinoa SPA routing configuration won't work with RESTEasy Classic. If not set, it is disabled.
 --|boolean 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.ignored-path-prefixes]]`link:#quarkus-quinoa_quarkus.quinoa.ignored-path-prefixes[quarkus.quinoa.ignored-path-prefixes]`
+
+[.description]
+--
+List of path prefixes to be ignored by Quinoa. If not set, "quarkus.rest.path", "quarkus.resteasy.path" and "quarkus.http.non-application-root-path" will be ignored.
+--|list of string 
 |
 
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -88,7 +88,7 @@ $ quarkus dev
 2022-03-28 09:24:46,741 INFO  [io.qua.qui.dep.QuinoaProcessor] (build-25) Quinoa generated resource: '/simple-greeting.js'
 ----
 
-NOTE: With Quinoa, you don't need to manually copy the files to `META-INF/resources`. Quinoa has its own system and will provide another Vert.x route for it. If you have conflicting files in `META-INF/resources`, they will have priority over Quinoa.
+WARNING: With Quinoa, you don't need to manually copy the files to `META-INF/resources`. Quinoa has its own system and will provide another Vert.x route for it. *If you have conflicting files in `META-INF/resources`, they will have priority over Quinoa.*
 
 [#how-to]
 == How to use the extension.
@@ -197,12 +197,37 @@ Edit the karma.conf.js:
 
 Client-side/Browser/SPA routing is the internal handling of a route from the javascript in the browser. It uses the https://developer.mozilla.org/en-US/docs/Web/API/History[HTML5 History API]
 
-When enabled, to allow SPA routing, all unhandled requests will be internally re-routed to index.html, this way the javascript can take care of the route inside the web-application.
+When enabled, to allow SPA routing, all relevant requests will be internally re-routed to index.html, this way the javascript can take care of the route inside the web-application.
 
 To enable Single Page application routing:
 [source,properties]
 ----
 quarkus.quinoa.enable-spa-routing=true
+----
+
+NOTE: By default, Quinoa will ignore `quarkus.rest.path`, `quarkus.resteasy.path` and `quarkus.http.non-application-root-path` path prefixes. You can specify different path prefixes to ignore using `quarkus.quinoa.ignored-path-prefixes`.
+
+WARNING: Currently, for technical reasons, the Quinoa SPA routing configuration won't work with RESTEasy Classic. Instead, you may use a workaround (if your app has all the rest resources under the same path prefix):
+[source,java]
+----
+@ApplicationScoped
+public class SPARouting {
+    private static final String[] PATH_PREFIXES = { "/api/", "/q/" };
+    private static final Predicate<String> FILE_NAME_PREDICATE = Pattern.compile(".*[.][a-zA-Z\\d]+").asMatchPredicate();
+
+    public void init(@Observes Router router) {
+        router.get("/*").handler(rc -> {
+            final String path = rc.normalizedPath();
+            if (!path.equals("/")
+                    && Stream.of(PATH_PREFIXES).noneMatch(path::startsWith)
+                    && !FILE_NAME_PREDICATE.test(path)) {
+                rc.reroute("/");
+            } else {
+                rc.next();
+            }
+        });
+    }
+}
 ----
 
 [#headers]

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 quarkus.http.header.Pragma.value=no-cache
 quarkus.http.header.Pragma.path=/headers/pragma
 quarkus.http.header.Pragma.methods=GET,HEAD
+%root-path.quarkus.quinoa.ui-dir=src/main/ui-react
+%root-path.quarkus.http.root-path=/foo/bar
 %react.quarkus.quinoa.ui-dir=src/main/ui-react
 %vue.quarkus.quinoa.ui-dir=src/main/ui-vue
 %vue.quarkus.quinoa.build-dir=dist
@@ -11,6 +13,7 @@ quarkus.http.header.Pragma.methods=GET,HEAD
 %lit.quarkus.quinoa.build-dir=dist
 %yarn.quarkus.quinoa.package-manager=yarn
 %yarn.quarkus.quinoa.ui-dir=src/main/ui-react
+
 
 %angular-dev.quarkus.quinoa.dev-server-port=4200
 %angular-dev.quarkus.quinoa.ui-dir=src/main/ui-angular

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
@@ -1,6 +1,9 @@
 package io.quarkiverse.quinoa;
 
+import static io.quarkus.vertx.http.runtime.VertxHttpRecorder.DEFAULT_ROUTE_ORDER;
+
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -15,14 +18,32 @@ import io.vertx.ext.web.RoutingContext;
 public class QuinoaRecorder {
     private static final Logger LOG = Logger.getLogger(QuinoaRecorder.class);
     public static final String META_INF_WEB_UI = "META-INF/webui";
+    public static final int QUINOA_ROUTE_ORDER = DEFAULT_ROUTE_ORDER + 1;
+    public static final int QUINOA_SPA_ROUTE_ORDER = DEFAULT_ROUTE_ORDER + 10_100;
 
-    public Handler<RoutingContext> quinoaProxyDevHandler(Supplier<Vertx> vertx, final Integer port) {
-        return new QuinoaDevProxyHandler(vertx.get(), port);
+    public Handler<RoutingContext> quinoaProxyDevHandler(Supplier<Vertx> vertx, int port,
+            final List<String> ignoredPathPrefixes) {
+        return new QuinoaDevProxyHandler(vertx.get(), port, ignoredPathPrefixes);
+    }
+
+    public Handler<RoutingContext> quinoaSPARoutingHandler(final List<String> ignoredPathPrefixes) throws IOException {
+        return new QuinoaSPARoutingHandler(ignoredPathPrefixes);
     }
 
     public Handler<RoutingContext> quinoaHandler(final String directory, final Set<String> uiResources,
-            boolean enableSPARouting) throws IOException {
-        return new QuinoaUIResourceHandler(directory, uiResources, enableSPARouting);
+            final List<String> ignoredPathPrefixes) throws IOException {
+        return new QuinoaUIResourceHandler(directory, uiResources, ignoredPathPrefixes);
+    }
+
+    static String resolvePath(RoutingContext ctx) {
+        return (ctx.mountPoint() == null) ? ctx.normalizedPath()
+                : ctx.normalizedPath().substring(
+                        // let's be extra careful here in case Vert.x normalizes the mount points at some point
+                        ctx.mountPoint().endsWith("/") ? ctx.mountPoint().length() - 1 : ctx.mountPoint().length());
+    }
+
+    static boolean isIgnored(final String path, final List<String> ignoredPathPrefixes) {
+        return ignoredPathPrefixes.stream().anyMatch(path::startsWith);
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaSPARoutingHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaSPARoutingHandler.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.quinoa;
+
+import static io.quarkiverse.quinoa.QuinoaRecorder.isIgnored;
+import static io.quarkiverse.quinoa.QuinoaRecorder.resolvePath;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+class QuinoaSPARoutingHandler implements Handler<RoutingContext> {
+    private static final Logger LOG = Logger.getLogger(QuinoaSPARoutingHandler.class);
+    private final List<String> ignoredPathPrefixes;
+    private final ClassLoader currentClassLoader;
+
+    public QuinoaSPARoutingHandler(List<String> ignoredPathPrefixes) {
+        this.ignoredPathPrefixes = ignoredPathPrefixes;
+        currentClassLoader = Thread.currentThread().getContextClassLoader();
+    }
+
+    @Override
+    public void handle(RoutingContext ctx) {
+        String path = resolvePath(ctx);
+        if (!Objects.equals(path, "/") && !isIgnored(path, ignoredPathPrefixes)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debugf("Quinoa is re-routing SPA request '%s' to '/'", ctx.normalizedPath());
+            }
+            ctx.reroute("/");
+        } else {
+            next(ctx);
+        }
+    }
+
+    private void next(RoutingContext ctx) {
+        // make sure we don't lose the correct TCCL to Vert.x...
+        Thread.currentThread().setContextClassLoader(currentClassLoader);
+        ctx.next();
+    }
+}


### PR DESCRIPTION
Before this in proxy dev-mode, META-INF/resources had priority over Quinoa and not in prod mode. 

This PR:

- Proxy dev-mode and prod mode behave the same,  META-INF/resources has priority over Quinoa.
- Introduce `quarkus.quinoa.ignored-path-prefixes` (Fixes https://github.com/quarkiverse/quarkus-quinoa/issues/62)

ping @sberyozkin @geoand @maxandersen 

