### PR TITLE
Update to Quarkus 2.10.0.Final

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/devmode/ClassicDevModeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/devmode/ClassicDevModeTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
-@Disabled // See https://github.com/quarkusio/quarkus/pull/25504
 public class ClassicDevModeTest {
     @RegisterExtension
     final static QuarkusDevModeTest test = new QuarkusDevModeTest()

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/devmode/ForwardedDevModeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/devmode/ForwardedDevModeTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
-@Disabled // See https://github.com/quarkusio/quarkus/pull/25504
 public class ForwardedDevModeTest {
     @RegisterExtension
     final static QuarkusDevModeTest test = new QuarkusDevModeTest()

--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,16 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>2.9.2.Final</quarkus.version>
+    <quarkus.version>2.10.0.Final</quarkus.version>
     <playright.version>1.22.0</playright.version>
     <assertj.version>3.23.1</assertj.version>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.quarkus.platform</groupId>
+        <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>
-        <version>2.9.2.Final</version>
+        <version>${quarkus.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -46,7 +46,7 @@
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
         <version>${quarkus.version}</version>
         <executions>
           <execution>


### PR DESCRIPTION
Enable dev-mode test thanks to the fix https://github.com/quarkusio/quarkus/pull/25504  released.


@aloubyansky is it ok to depend on the core bom?
```xml
        <groupId>io.quarkus</groupId>
        <artifactId>quarkus-bom</artifactId>
```