### PR TITLE
Clean config names & introduce "quarkus.quinoa.dev-server.*" 

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/DevServerConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/DevServerConfig.java
@@ -1,0 +1,72 @@
+package io.quarkiverse.quinoa.deployment;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class DevServerConfig {
+
+    private static final int DEFAULT_DEV_SERVER_TIMEOUT = 30000;
+
+    /**
+     * Enable external dev server (live coding).
+     * The dev server process (i.e npm start) is managed like a dev service by Quarkus.
+     * This defines the port of the server to forward requests to.
+     * If the external server responds with a 404, it is ignored by Quinoa and processed like any other backend request.
+     */
+    @ConfigItem
+    public OptionalInt port;
+
+    /**
+     * After start, Quinoa wait for the external dev server.
+     * by sending GET requests to this path waiting for a 200 status.
+     *
+     * If not set the default is "/".
+     * If empty string "", Quinoa will not check if the dev server is up.
+     */
+    @ConfigItem(defaultValue = "/")
+    public Optional<String> checkPath;
+
+    /**
+     * Timeout in ms for the dev server to be up and running.
+     * If not set the default is ~30000ms
+     */
+    @ConfigItem(defaultValueDocumentation = "30000")
+    public OptionalInt checkTimeout;
+
+    /**
+     * Enable external dev server live coding logs.
+     * This is not enabled by default because most dev servers display compilation errors directly in the browser.
+     * False if not set.
+     */
+    @ConfigItem
+    public Optional<Boolean> logs;
+
+    public int checkTimeout() {
+        return checkTimeout.orElse(DEFAULT_DEV_SERVER_TIMEOUT);
+    }
+
+    public boolean isLogsEnabled() {
+        return logs.orElse(false);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DevServerConfig that = (DevServerConfig) o;
+        return Objects.equals(port, that.port) && Objects.equals(checkPath, that.checkPath)
+                && Objects.equals(checkTimeout, that.checkTimeout) && Objects.equals(logs, that.logs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(port, checkPath, checkTimeout, logs);
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaConfig.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -20,39 +19,38 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class QuinoaConfig {
 
     private static final String DEFAULT_WEB_UI_DIR = "src/main/webui";
-    private static final int DEFAULT_DEV_SERVER_TIMEOUT = 30000;
     private static final String DEFAULT_INDEX_PAGE = "index.html";
 
     /**
-     * Indicate if the extension should be enabled
-     * Default is true if the Web UI directory exists and dev and prod mode
-     * Default is false in test mode (to avoid building the Web UI during backend tests)
+     * Indicate if the extension should be enabled.
+     * Default is true if the Web UI directory exists and dev and prod mode.
+     * Default is false in test mode (to avoid building the Web UI during backend tests).
      */
     @ConfigItem(name = ConfigItem.PARENT)
     Optional<Boolean> enable;
 
     /**
      * Path to the Web UI (node) root directory.
-     * If not set ${project.root}/src/main/webui/ will be used
-     * otherwise the path will be considered relative to the project root
+     * If not set ${project.root}/src/main/webui/ will be used.
+     * otherwise the path will be considered relative to the project root.
      */
-    @ConfigItem
+    @ConfigItem(defaultValueDocumentation = "src/main/webui/")
     public Optional<String> uiDir;
 
     /**
      * Path of the directory which contains the Web UI built files (generated during the build).
      * After the build, Quinoa will take the files from this directory,
      * move them to target/quinoa-build (or build/quinoa-build with Gradle) and serve them at runtime.
-     * The path is relative to the Web UI path
+     * The path is relative to the Web UI path.
      * If not set "build/" will be used
      */
-    @ConfigItem
+    @ConfigItem(defaultValueDocumentation = "build/")
     public Optional<String> buildDir;
 
     /**
      * Name of the package manager binary.
      * If not set, it will be auto-detected depending on the lockfile falling back to "npm".
-     * Only npm, pnpm and yarn are supported for the moment
+     * Only npm, pnpm and yarn are supported for the moment.
      */
     @ConfigItem
     public Optional<String> packageManager;
@@ -61,38 +59,38 @@ public class QuinoaConfig {
      * Name of the index page.
      * If not set, "index.html" will be used.
      */
-    @ConfigItem
+    @ConfigItem(defaultValueDocumentation = "index.html")
     public Optional<String> indexPage;
 
     /**
-     * Indicate if the Web UI should also be tested during the build phase (i.e: npm test)
+     * Indicate if the Web UI should also be tested during the build phase (i.e: npm test).
      * To be used in a {@link io.quarkus.test.junit.QuarkusTestProfile} to have Web UI test running during a
      * {@link io.quarkus.test.junit.QuarkusTest}
-     * Default is false
+     * Default is false.
      */
-    @ConfigItem(name = "run-tests")
+    @ConfigItem(name = "run-tests", defaultValueDocumentation = "false")
     Optional<Boolean> runTests;
 
     /**
      * Install the packages using a frozen lockfile. Don’t generate a lockfile and fail if an update is needed (useful in CI).
-     * If not set it is true if environment CI=true, else it is false
+     * If not set it is true if environment CI=true, else it is false.
      */
     @ConfigItem
     public Optional<Boolean> frozenLockfile;
 
     /**
-     * Always install packages before building.
+     * Force install packages before building.
      * If not set, it will install packages only if the node_modules directory is absent.
      */
-    @ConfigItem
-    public Optional<Boolean> alwaysInstall;
+    @ConfigItem(defaultValueDocumentation = "false")
+    public Optional<Boolean> forceInstall;
 
     /**
-     * Enable SPA (Single Page Application) routing, all relevant requests will be re-routed to the index.html
+     * Enable SPA (Single Page Application) routing, all relevant requests will be re-routed to the "index.html".
      * Currently, for technical reasons, the Quinoa SPA routing configuration won't work with RESTEasy Classic.
      * If not set, it is disabled.
      */
-    @ConfigItem
+    @ConfigItem(defaultValueDocumentation = "false")
     public Optional<Boolean> enableSPARouting;
 
     /**
@@ -103,37 +101,19 @@ public class QuinoaConfig {
     public Optional<List<String>> ignoredPathPrefixes;
 
     /**
-     * Enable external server for dev (live coding).
-     * The dev server process (i.e npm start) is managed like a dev service by Quarkus.
-     * This defines the port of the server to forward requests to.
-     * If the external server responds with a 404, it is ignored by Quinoa and processed like any other backend request.
+     * Configuration for the external dev server (live coding server)
      */
     @ConfigItem
-    public OptionalInt devServerPort;
-
-    /**
-     * Timeout in ms for the dev server to be up and running.
-     * If not set the default is ~30000ms
-     */
-    @ConfigItem
-    public OptionalInt devServerTimeout;
-
-    /**
-     * Enable external dev server live coding logs.
-     * This is not enabled by default because most dev servers display compilation errors directly in the browser.
-     * False if not set.
-     */
-    @ConfigItem
-    public Optional<Boolean> enableDevServerLogs;
+    public DevServerConfig devServer;
 
     public List<String> getNormalizedIgnoredPathPrefixes() {
         return ignoredPathPrefixes.orElseGet(() -> {
             Config config = ConfigProvider.getConfig();
-            List<String> defaultIgnored = new ArrayList<>();
-            readExternalConfigPath(config, "quarkus.resteasy.path").ifPresent(defaultIgnored::add);
-            readExternalConfigPath(config, "quarkus.rest.path").ifPresent(defaultIgnored::add);
-            readExternalConfigPath(config, "quarkus.http.non-application-root-path").ifPresent(defaultIgnored::add);
-            return defaultIgnored;
+            List<String> defaultIgnore = new ArrayList<>();
+            readExternalConfigPath(config, "quarkus.resteasy.path").ifPresent(defaultIgnore::add);
+            readExternalConfigPath(config, "quarkus.rest.path").ifPresent(defaultIgnore::add);
+            readExternalConfigPath(config, "quarkus.http.non-application-root-path").ifPresent(defaultIgnore::add);
+            return defaultIgnore;
         }).stream().map(s -> s.startsWith("/") ? s : "/" + s).collect(toList());
     }
 
@@ -156,19 +136,11 @@ public class QuinoaConfig {
     }
 
     public String getBuildDir() {
-        return buildDir.orElse("build");
-    }
-
-    public int getDevServerTimeout() {
-        return devServerTimeout.orElse(DEFAULT_DEV_SERVER_TIMEOUT);
+        return buildDir.orElse("build/");
     }
 
     public boolean shouldRunTests() {
         return runTests.orElse(false);
-    }
-
-    public boolean shouldEnableDevServerLogs() {
-        return enableDevServerLogs.orElse(false);
     }
 
     public boolean isEnabled() {
@@ -186,17 +158,18 @@ public class QuinoaConfig {
         if (o == null || getClass() != o.getClass())
             return false;
         QuinoaConfig that = (QuinoaConfig) o;
-        return enable.equals(that.enable) && uiDir.equals(that.uiDir) && buildDir.equals(that.buildDir) &&
-                packageManager.equals(that.packageManager) && runTests.equals(that.runTests) &&
-                frozenLockfile.equals(that.frozenLockfile) && alwaysInstall.equals(that.alwaysInstall) &&
-                enableSPARouting.equals(that.enableSPARouting) && ignoredPathPrefixes.equals(that.ignoredPathPrefixes) &&
-                devServerPort.equals(that.devServerPort) && devServerTimeout.equals(that.devServerTimeout) &&
-                enableDevServerLogs.equals(that.enableDevServerLogs);
+        return Objects.equals(enable, that.enable) && Objects.equals(uiDir, that.uiDir)
+                && Objects.equals(buildDir, that.buildDir) && Objects.equals(packageManager, that.packageManager)
+                && Objects.equals(indexPage, that.indexPage) && Objects.equals(runTests, that.runTests)
+                && Objects.equals(frozenLockfile, that.frozenLockfile) && Objects.equals(forceInstall, that.forceInstall)
+                && Objects.equals(enableSPARouting, that.enableSPARouting)
+                && Objects.equals(ignoredPathPrefixes, that.ignoredPathPrefixes)
+                && Objects.equals(devServer, that.devServer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enable, uiDir, buildDir, packageManager, runTests, frozenLockfile, alwaysInstall,
-                enableSPARouting, ignoredPathPrefixes, devServerPort, devServerTimeout, enableDevServerLogs);
+        return Objects.hash(enable, uiDir, buildDir, packageManager, indexPage, runTests, frozenLockfile, forceInstall,
+                enableSPARouting, ignoredPathPrefixes, devServer);
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -92,7 +92,7 @@ public class QuinoaProcessor {
         final boolean alreadyInstalled = Files.isDirectory(packageManager.getDirectory().resolve("node_modules"));
         final boolean packageFileModified = liveReload.isLiveReload()
                 && liveReload.getChangedResources().stream().anyMatch(r -> r.equals(packageFile.toString()));
-        if (quinoaConfig.alwaysInstall.orElse(!alreadyInstalled || packageFileModified)) {
+        if (quinoaConfig.forceInstall.orElse(!alreadyInstalled || packageFileModified)) {
             final boolean frozenLockfile = quinoaConfig.frozenLockfile.orElseGet(QuinoaProcessor::isCI);
             packageManager.install(frozenLockfile);
         }
@@ -112,7 +112,7 @@ public class QuinoaProcessor {
 
         final PackageManager packageManager = quinoaDir.get().getPackageManager();
         final QuinoaLiveContext contextObject = liveReload.getContextObject(QuinoaLiveContext.class);
-        if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT && quinoaConfig.devServerPort.isPresent()) {
+        if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT && quinoaConfig.devServer.port.isPresent()) {
             return null;
         }
         if (liveReload.isLiveReload()
@@ -167,7 +167,7 @@ public class QuinoaProcessor {
             QuinoaConfig quinoaConfig,
             Optional<QuinoaDirectoryBuildItem> quinoaDir,
             BuildProducer<HotDeploymentWatchedFileBuildItem> watchedPaths) throws IOException {
-        if (!quinoaDir.isPresent() || quinoaConfig.devServerPort.isPresent()) {
+        if (!quinoaDir.isPresent() || quinoaConfig.devServer.port.isPresent()) {
             return;
         }
         scan(quinoaDir.get().getPackageManager().getDirectory(), watchedPaths);

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaFrozenLockfileConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaFrozenLockfileConfigTest.java
@@ -18,7 +18,7 @@ public class QuinoaFrozenLockfileConfigTest {
             .initialLockFile(YARN)
             .ci(null)
             .toQuarkusUnitTest()
-            .overrideConfigKey("quarkus.quinoa.always-install", "true")
+            .overrideConfigKey("quarkus.quinoa.force-install", "true")
             .overrideConfigKey("quarkus.quinoa.frozen-lockfile", "true")
             .assertLogRecords(l -> {
                 assertThat(l).anySatisfy(s -> {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerManualYarnConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerManualYarnConfigTest.java
@@ -14,7 +14,7 @@ public class QuinoaPackageManagerManualYarnConfigTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create().toQuarkusUnitTest()
-            .overrideConfigKey("quarkus.quinoa.always-install", "true")
+            .overrideConfigKey("quarkus.quinoa.force-install", "true")
             .overrideConfigKey("quarkus.quinoa.package-manager", "yarn")
             .overrideConfigKey("quarkus.quinoa.frozen-lockfile", "false")
             .assertLogRecords(l -> {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerNPMConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerNPMConfigTest.java
@@ -13,7 +13,7 @@ import io.quarkus.test.QuarkusUnitTest;
 public class QuinoaPackageManagerNPMConfigTest {
     @RegisterExtension
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create().toQuarkusUnitTest()
-            .overrideConfigKey("quarkus.quinoa.always-install", "true")
+            .overrideConfigKey("quarkus.quinoa.force-install", "true")
             .assertLogRecords(l -> {
                 assertThat(l).anySatisfy(s -> {
                     assertThat(s.getMessage()).isEqualTo("Running Quinoa package manager build command: %s");

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerNpmConfigBinaryOnWindowsTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerNpmConfigBinaryOnWindowsTest.java
@@ -14,7 +14,7 @@ public class QuinoaPackageManagerNpmConfigBinaryOnWindowsTest {
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create()
             .osName("Windows One")
             .toQuarkusUnitTest()
-            .overrideConfigKey("quarkus.quinoa.always-install", "true")
+            .overrideConfigKey("quarkus.quinoa.force-install", "true")
             .assertLogRecords(l -> {
                 assertThat(l).anySatisfy(s -> {
                     assertThat(s.getMessage()).isEqualTo("Running Quinoa package manager install command: %s");

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerPNPMConfigBinaryOnWindowsTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerPNPMConfigBinaryOnWindowsTest.java
@@ -16,7 +16,7 @@ public class QuinoaPackageManagerPNPMConfigBinaryOnWindowsTest {
             .initialLockFile(PNPM)
             .osName("Windows One")
             .toQuarkusUnitTest()
-            .overrideConfigKey("quarkus.quinoa.always-install", "true")
+            .overrideConfigKey("quarkus.quinoa.force-install", "true")
             .assertLogRecords(l -> {
                 assertThat(l).anySatisfy(s -> {
                     assertThat(s.getMessage()).isEqualTo("Running Quinoa package manager install command: %s");

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerPNPMConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerPNPMConfigTest.java
@@ -17,7 +17,7 @@ public class QuinoaPackageManagerPNPMConfigTest {
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create()
             .initialLockFile(PNPM)
             .toQuarkusUnitTest()
-            .overrideConfigKey("quarkus.quinoa.always-install", "true")
+            .overrideConfigKey("quarkus.quinoa.force-install", "true")
             .assertLogRecords(l -> {
                 assertThat(l).anySatisfy(s -> {
                     assertThat(s.getMessage()).isEqualTo("Running Quinoa package manager build command: %s");

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerYarnConfigBinaryOnWindowsTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerYarnConfigBinaryOnWindowsTest.java
@@ -16,7 +16,7 @@ public class QuinoaPackageManagerYarnConfigBinaryOnWindowsTest {
             .initialLockFile(YARN)
             .osName("Windows One")
             .toQuarkusUnitTest()
-            .overrideConfigKey("quarkus.quinoa.always-install", "true")
+            .overrideConfigKey("quarkus.quinoa.force-install", "true")
             .assertLogRecords(l -> {
                 assertThat(l).anySatisfy(s -> {
                     assertThat(s.getMessage()).isEqualTo("Running Quinoa package manager install command: %s");

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerYarnConfigBinaryTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerYarnConfigBinaryTest.java
@@ -16,7 +16,7 @@ public class QuinoaPackageManagerYarnConfigBinaryTest {
             .initialLockFile(YARN)
             .toQuarkusUnitTest()
             .overrideConfigKey("quarkus.quinoa.package-manager", "yarn.binary")
-            .overrideConfigKey("quarkus.quinoa.always-install", "true")
+            .overrideConfigKey("quarkus.quinoa.force-install", "true")
             .assertException(e -> {
                 assertThat(e).hasMessage("Input/Output error while executing command.");
                 assertThat(e.getCause()).hasMessageContaining("yarn.binary");

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerYarnConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerYarnConfigTest.java
@@ -17,7 +17,7 @@ public class QuinoaPackageManagerYarnConfigTest {
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create()
             .initialLockFile(YARN)
             .toQuarkusUnitTest()
-            .overrideConfigKey("quarkus.quinoa.always-install", "true")
+            .overrideConfigKey("quarkus.quinoa.force-install", "true")
             .assertLogRecords(l -> {
                 assertThat(l).anySatisfy(s -> {
                     assertThat(s.getMessage()).isEqualTo("Running Quinoa package manager build command: %s");

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/devmode/ClassicDevModeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/devmode/ClassicDevModeTest.java
@@ -2,7 +2,6 @@ package io.quarkiverse.quinoa.test.devmode;
 
 import static org.hamcrest.Matchers.is;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/devmode/ForwardedDevModeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/devmode/ForwardedDevModeTest.java
@@ -2,7 +2,6 @@ package io.quarkiverse.quinoa.test.devmode;
 
 import static org.hamcrest.Matchers.is;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 

--- a/deployment/src/test/resources/application-forwarded.properties
+++ b/deployment/src/test/resources/application-forwarded.properties
@@ -1,3 +1,3 @@
 quarkus.quinoa=true
 quarkus.quinoa.ui-dir=src/main/webui
-quarkus.quinoa.dev-server-port=3000
+quarkus.quinoa.dev-server.port=3000

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.9.2.Final
+:quarkus-version: 2.10.0.Final
 :quarkus-quinoa-version: 1.0.6
 :maven-version: 3.8.1+
 

--- a/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
@@ -12,7 +12,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa]]`link:#q
 
 [.description]
 --
-Indicate if the extension should be enabled Default is true if the Web UI directory exists and dev and prod mode Default is false in test mode (to avoid building the Web UI during backend tests)
+Indicate if the extension should be enabled. Default is true if the Web UI directory exists and dev and prod mode. Default is false in test mode (to avoid building the Web UI during backend tests).
 --|boolean 
 |
 
@@ -21,25 +21,25 @@ a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.ui-dir]]`
 
 [.description]
 --
-Path to the Web UI (node) root directory. If not set $++{++project.root++}++/src/main/webui/ will be used otherwise the path will be considered relative to the project root
+Path to the Web UI (node) root directory. If not set $++{++project.root++}++/src/main/webui/ will be used. otherwise the path will be considered relative to the project root.
 --|string 
-|
+|`src/main/webui/`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.build-dir]]`link:#quarkus-quinoa_quarkus.quinoa.build-dir[quarkus.quinoa.build-dir]`
 
 [.description]
 --
-Path of the directory which contains the Web UI built files (generated during the build). After the build, Quinoa will take the files from this directory, move them to target/quinoa-build (or build/quinoa-build with Gradle) and serve them at runtime. The path is relative to the Web UI path If not set "build/" will be used
+Path of the directory which contains the Web UI built files (generated during the build). After the build, Quinoa will take the files from this directory, move them to target/quinoa-build (or build/quinoa-build with Gradle) and serve them at runtime. The path is relative to the Web UI path. If not set "build/" will be used
 --|string 
-|
+|`build/`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.package-manager]]`link:#quarkus-quinoa_quarkus.quinoa.package-manager[quarkus.quinoa.package-manager]`
 
 [.description]
 --
-Name of the package manager binary. If not set, it will be auto-detected depending on the lockfile falling back to "npm". Only npm, pnpm and yarn are supported for the moment
+Name of the package manager binary. If not set, it will be auto-detected depending on the lockfile falling back to "npm". Only npm, pnpm and yarn are supported for the moment.
 --|string 
 |
 
@@ -50,43 +50,43 @@ a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.index-pag
 --
 Name of the index page. If not set, "index.html" will be used.
 --|string 
-|
+|`index.html`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.run-tests]]`link:#quarkus-quinoa_quarkus.quinoa.run-tests[quarkus.quinoa.run-tests]`
 
 [.description]
 --
-Indicate if the Web UI should also be tested during the build phase (i.e: npm test) To be used in a `io.quarkus.test.junit.QuarkusTestProfile` to have Web UI test running during a `io.quarkus.test.junit.QuarkusTest` Default is false
+Indicate if the Web UI should also be tested during the build phase (i.e: npm test). To be used in a `io.quarkus.test.junit.QuarkusTestProfile` to have Web UI test running during a `io.quarkus.test.junit.QuarkusTest` Default is false.
 --|boolean 
-|
+|`false`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.frozen-lockfile]]`link:#quarkus-quinoa_quarkus.quinoa.frozen-lockfile[quarkus.quinoa.frozen-lockfile]`
 
 [.description]
 --
-Install the packages using a frozen lockfile. Don’t generate a lockfile and fail if an update is needed (useful in CI). If not set it is true if environment CI=true, else it is false
+Install the packages using a frozen lockfile. Don’t generate a lockfile and fail if an update is needed (useful in CI). If not set it is true if environment CI=true, else it is false.
 --|boolean 
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.always-install]]`link:#quarkus-quinoa_quarkus.quinoa.always-install[quarkus.quinoa.always-install]`
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.force-install]]`link:#quarkus-quinoa_quarkus.quinoa.force-install[quarkus.quinoa.force-install]`
 
 [.description]
 --
-Always install packages before building. If not set, it will install packages only if the node_modules directory is absent.
+Force install packages before building. If not set, it will install packages only if the node_modules directory is absent.
 --|boolean 
-|
+|`false`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.enable-spa-routing]]`link:#quarkus-quinoa_quarkus.quinoa.enable-spa-routing[quarkus.quinoa.enable-spa-routing]`
 
 [.description]
 --
-Enable SPA (Single Page Application) routing, all relevant requests will be re-routed to the index.html Currently, for technical reasons, the Quinoa SPA routing configuration won't work with RESTEasy Classic. If not set, it is disabled.
+Enable SPA (Single Page Application) routing, all relevant requests will be re-routed to the "index.html". Currently, for technical reasons, the Quinoa SPA routing configuration won't work with RESTEasy Classic. If not set, it is disabled.
 --|boolean 
-|
+|`false`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.ignored-path-prefixes]]`link:#quarkus-quinoa_quarkus.quinoa.ignored-path-prefixes[quarkus.quinoa.ignored-path-prefixes]`
@@ -98,25 +98,34 @@ List of path prefixes to be ignored by Quinoa. If not set, "quarkus.rest.path", 
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.dev-server-port]]`link:#quarkus-quinoa_quarkus.quinoa.dev-server-port[quarkus.quinoa.dev-server-port]`
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.dev-server.port]]`link:#quarkus-quinoa_quarkus.quinoa.dev-server.port[quarkus.quinoa.dev-server.port]`
 
 [.description]
 --
-Enable external server for dev (live coding). The dev server process (i.e npm start) is managed like a dev service by Quarkus. This defines the port of the server to forward requests to. If the external server responds with a 404, it is ignored by Quinoa and processed like any other backend request.
+Enable external dev server (live coding). The dev server process (i.e npm start) is managed like a dev service by Quarkus. This defines the port of the server to forward requests to. If the external server responds with a 404, it is ignored by Quinoa and processed like any other backend request.
 --|int 
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.dev-server-timeout]]`link:#quarkus-quinoa_quarkus.quinoa.dev-server-timeout[quarkus.quinoa.dev-server-timeout]`
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.dev-server.check-path]]`link:#quarkus-quinoa_quarkus.quinoa.dev-server.check-path[quarkus.quinoa.dev-server.check-path]`
+
+[.description]
+--
+After start, Quinoa wait for the external dev server. by sending GET requests to this path waiting for a 200 status. If not set the default is "/". If empty string "", Quinoa will not check if the dev server is up.
+--|string 
+|`/`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.dev-server.check-timeout]]`link:#quarkus-quinoa_quarkus.quinoa.dev-server.check-timeout[quarkus.quinoa.dev-server.check-timeout]`
 
 [.description]
 --
 Timeout in ms for the dev server to be up and running. If not set the default is ~30000ms
 --|int 
-|
+|`30000`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.enable-dev-server-logs]]`link:#quarkus-quinoa_quarkus.quinoa.enable-dev-server-logs[quarkus.quinoa.enable-dev-server-logs]`
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.dev-server.logs]]`link:#quarkus-quinoa_quarkus.quinoa.dev-server.logs[quarkus.quinoa.dev-server.logs]`
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -182,7 +182,7 @@ NOTE: Quinoa is configured with the commands to call depending on the chosen pac
 
 By default, Quinoa will call the appropriate package manager install command (before building or starting) *only if* the `node_modules` directory doesn't exist.
 
-You may force a new installation using `-Dquarkus.quinoa.always-install=true`.
+You may force a new installation using `-Dquarkus.quinoa.force-install=true`.
 
 [#frozen-lockfile]
 NOTE: Quinoa will use the appropriate package manager frozen-lockfile command when installing, if the environment `CI=true`, or if `quarkus.quinoa.frozen-lockfile=true`. In this mode, the lockfile have to be present in the project.
@@ -193,7 +193,7 @@ NOTE: Quinoa will use the appropriate package manager frozen-lockfile command wh
 To enable the UI live-coding dev server, set a `start` script and set the port in the app config. Quinoa will transparently proxy relevant requests to the given port:
 [source,properties]
 ----
-quarkus.quinoa.dev-server-port=3000
+quarkus.quinoa.dev-server.port=3000
 ----
 
 NOTE: Quinoa relies on the dev server returning a 404 when the file is not found (See link:#how-dev-server[How it works]). This is not the case on some dev servers configured with SPA routing. Make sure it is disabled in the dev server configuration (for React Create App, see https://github.com/quarkiverse/quarkus-quinoa/issues/91[#91]). Another option, when possible, is to use <<quarkus-quinoa_quarkus.quinoa.ignored-path-prefixes>>.
@@ -206,7 +206,7 @@ App created by Create React App (https://create-react-app.dev/docs/getting-start
 To enable React live coding server:
 [source,properties]
 ----
-quarkus.quinoa.dev-server-port=3000
+quarkus.quinoa.dev-server.port=3000
 ----
 
 [#angular]
@@ -221,7 +221,7 @@ quarkus.quinoa.build-dir=dist/[your-app-name]
 To enable Angular live coding server, you need to edit the package.json start script with `ng serve --host 0.0.0.0 --no-live-reload`, then add this configuration:
 [source,properties]
 ----
-quarkus.quinoa.dev-server-port=4200
+quarkus.quinoa.dev-server.port=4200
 ----
 
 If you want to use the Angular tests (instead of Playwright from the @QuarkusTest):

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,6 +1,3 @@
-quarkus.http.header.Pragma.value=no-cache
-quarkus.http.header.Pragma.path=/headers/pragma
-quarkus.http.header.Pragma.methods=GET,HEAD
 %root-path.quarkus.quinoa.ui-dir=src/main/ui-lit
 %root-path.quarkus.http.root-path=/foo/bar
 %root-path.quarkus.quinoa.build-dir=dist
@@ -19,13 +16,13 @@ quarkus.http.header.Pragma.methods=GET,HEAD
 %yarn.quarkus.quinoa.ui-dir=src/main/ui-react
 
 
-%angular-dev.quarkus.quinoa.dev-server-port=4200
+%angular-dev.quarkus.quinoa.dev-server.port=4200
 %angular-dev.quarkus.quinoa.ui-dir=src/main/ui-angular
 %angular-dev.quarkus.quinoa.build-dir=dist/quinoa-app
 %angular-dev.quarkus.quinoa.enable-spa-routing=true
 %angular-dev.quarkus.rest.path=/bar/foo
 %react-dev.quarkus.quinoa.ui-dir=src/main/ui-react
-%react-dev.quarkus.quinoa.dev-server-port=3000
-%vue-dev.quarkus.quinoa.dev-server-port=3000
+%react-dev.quarkus.quinoa.dev-server.port=3000
+%vue-dev.quarkus.quinoa.dev-server.port=3000
 %vue-dev.quarkus.quinoa.ui-dir=src/main/ui-vue
 %vue-dev.quarkus.quinoa.build-dir=dist/

--- a/runtime/src/main/codestarts/quarkus/quinoa-codestart/base/src/main/resources/application.yml
+++ b/runtime/src/main/codestarts/quarkus/quinoa-codestart/base/src/main/resources/application.yml
@@ -1,3 +1,4 @@
 quarkus:
   quinoa:
-    dev-server-port: 3000
+    dev-server:
+      port: 3000


### PR DESCRIPTION
- Introduce `quarkus.quinoa.dev-server.check-path`: see doc.
- Rename `quarkus.quinoa.dev-server-port` to `quarkus.quinoa.dev-server.port`
- Rename `quarkus.quinoa.enable-dev-server-logs` to `quarkus.quinoa.dev-server.logs`
- Rename `quarkus.quinoa.dev-server-timeout` to `quarkus.quinoa.dev-server.check-timeout`
- Rename `quarkus.quinoa.always-install` to `quarkus.quinoa.force-install`
