### PR TITLE
Supplying more arguments for npm install

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaConfig.java
@@ -81,6 +81,11 @@ public class QuinoaConfig {
     public Optional<Boolean> frozenLockfile;
 
     /**
+     * Extra arguments to use when installing packets.
+     */
+    public Optional<String> installArguments;
+
+    /**
      * Force install packages before building.
      * If not set, it will install packages only if the node_modules directory is absent or when the package.json is modified in
      * dev-mode.

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -5,20 +5,14 @@ import static io.quarkiverse.quinoa.QuinoaRecorder.QUINOA_ROUTE_ORDER;
 import static io.quarkiverse.quinoa.QuinoaRecorder.QUINOA_SPA_ROUTE_ORDER;
 import static io.quarkiverse.quinoa.deployment.PackageManager.autoDetectPackageManager;
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
+import static java.util.Collections.emptyList;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.AbstractMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -95,7 +89,9 @@ public class QuinoaProcessor {
                 && liveReload.getChangedResources().stream().anyMatch(r -> r.equals(packageFile.toString()));
         if (quinoaConfig.forceInstall || !alreadyInstalled || packageFileModified) {
             final boolean frozenLockfile = quinoaConfig.frozenLockfile.orElseGet(QuinoaProcessor::isCI);
-            packageManager.install(frozenLockfile);
+            List<String> installArguments = quinoaConfig.installArguments.map(ia -> Arrays.asList(ia.split(" ")))
+                    .orElse(emptyList());
+            packageManager.install(frozenLockfile, installArguments);
         }
         return new QuinoaDirectoryBuildItem(packageManager);
     }

--- a/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
@@ -71,6 +71,15 @@ Install the packages using a frozen lockfile. Don’t generate a lockfile and fa
 |`true if environment CI=true`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.install-arguments]]`link:#quarkus-quinoa_quarkus.quinoa.install-arguments[quarkus.quinoa.install-arguments]`
+
+[.description]
+--
+
+--|string 
+|
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.force-install]]`link:#quarkus-quinoa_quarkus.quinoa.force-install[quarkus.quinoa.force-install]`
 
 [.description]


### PR DESCRIPTION
In our CI build we run 
```bash
npm ci --cache $CACHE_DIR/.npm --prefer-offline 
```
This code outlines support for supplying more arguments for the install-step.

```properties
quarkus.quinoa.install-arguments=--cache $CACHE_DIR/.npm --prefer-offline
```

```bash
[INFO] --- quarkus-maven-plugin:2.10.1.Final:build (default) @ swarm-overview ---
[INFO] [io.quarkiverse.quinoa.deployment.PackageManager] Running Quinoa package manager install command: npm ci --cache $CACHE_DIR/.npm --prefer-offline
[INFO] [io.quarkiverse.quinoa.deployment.PackageManager] 
[INFO] [io.quarkiverse.quinoa.deployment.PackageManager] added 1571 packages in 1m
```

Any feedback on this feature? 
I guess the same change should be done for all steps in the process.