### PR TITLE
Add config to enable/disable dev server

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/DevServerConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/DevServerConfig.java
@@ -12,8 +12,15 @@ public class DevServerConfig {
 
     /**
      * Enable external dev server (live coding).
+     * The "dev-server.port" config is required to communicate with the dev server.
+     * If not set the default is true.
+     */
+    @ConfigItem(name = ConfigItem.PARENT, defaultValue = "true")
+    public boolean enabled;
+
+    /**
+     * Port of the server to forward requests to.
      * The dev server process (i.e npm start) is managed like a dev service by Quarkus.
-     * This defines the port of the server to forward requests to.
      * If the external server responds with a 404, it is ignored by Quinoa and processed like any other backend request.
      */
     @ConfigItem
@@ -31,7 +38,7 @@ public class DevServerConfig {
 
     /**
      * Timeout in ms for the dev server to be up and running.
-     * If not set the default is ~30000ms
+     * If not set the default is ~30000ms.
      */
     @ConfigItem(defaultValue = "30000")
     public int checkTimeout;
@@ -51,12 +58,12 @@ public class DevServerConfig {
         if (o == null || getClass() != o.getClass())
             return false;
         DevServerConfig that = (DevServerConfig) o;
-        return Objects.equals(port, that.port) && Objects.equals(checkPath, that.checkPath)
-                && Objects.equals(checkTimeout, that.checkTimeout) && Objects.equals(logs, that.logs);
+        return checkTimeout == that.checkTimeout && logs == that.logs && Objects.equals(enabled, that.enabled)
+                && Objects.equals(port, that.port) && Objects.equals(checkPath, that.checkPath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(port, checkPath, checkTimeout, logs);
+        return Objects.hash(enabled, port, checkPath, checkTimeout, logs);
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
@@ -100,7 +100,7 @@ public class ForwardedDevProcessor {
             shutdown.addCloseTask(closeTask, true);
         }
 
-        if (quinoaConfig.devServer.port.isEmpty()) {
+        if (!quinoaConfig.isDevServerMode()) {
             return null;
         }
 
@@ -157,7 +157,7 @@ public class ForwardedDevProcessor {
             CoreVertxBuildItem vertx,
             BuildProducer<RouteBuildItem> routes,
             BuildProducer<ResumeOn404BuildItem> resumeOn404) throws IOException {
-        if (quinoaConfig.devServer.port.isPresent() && devProxy.isPresent()) {
+        if (quinoaConfig.isDevServerMode() && devProxy.isPresent()) {
             LOG.infof("Quinoa is forwarding unhandled requests to port: %d", quinoaConfig.devServer.port.getAsInt());
             final QuinoaHandlerConfig handlerConfig = quinoaConfig.toHandlerConfig(false, httpBuildTimeConfig);
             routes.produce(RouteBuildItem.builder().orderedRoute("/*", QUINOA_ROUTE_ORDER)

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaConfig.java
@@ -117,6 +117,10 @@ public class QuinoaConfig {
     @ConfigItem
     public PackageManagerCommandsConfig packageManagerCommand;
 
+    public boolean isDevServerMode() {
+        return devServer.enabled && devServer.port.isPresent();
+    }
+
     public List<String> getNormalizedIgnoredPathPrefixes() {
         return ignoredPathPrefixes.orElseGet(() -> {
             Config config = ConfigProvider.getConfig();

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -115,7 +115,7 @@ public class QuinoaProcessor {
 
         final PackageManager packageManager = quinoaDir.get().getPackageManager();
         final QuinoaLiveContext contextObject = liveReload.getContextObject(QuinoaLiveContext.class);
-        if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT && quinoaConfig.devServer.port.isPresent()) {
+        if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT && quinoaConfig.isDevServerMode()) {
             return null;
         }
         if (liveReload.isLiveReload()
@@ -170,7 +170,7 @@ public class QuinoaProcessor {
             QuinoaConfig quinoaConfig,
             Optional<QuinoaDirectoryBuildItem> quinoaDir,
             BuildProducer<HotDeploymentWatchedFileBuildItem> watchedPaths) throws IOException {
-        if (!quinoaDir.isPresent() || quinoaConfig.devServer.port.isPresent()) {
+        if (!quinoaDir.isPresent() || quinoaConfig.isDevServerMode()) {
             return;
         }
         scan(quinoaDir.get().getPackageManager().getDirectory(), watchedPaths);

--- a/deployment/src/test/webui/package-lock.json
+++ b/deployment/src/test/webui/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "quinoa-app",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "quinoa-app",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  },
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  }
+}


### PR DESCRIPTION
As this is `quarkus.quinoa.dev-server` is true by default, it won't change the current behavior (the `quarkus.quinoa.dev-server.port` is controlling whether it's enabled or not). 

This config allow to change the dev-server mode (external or quarkus) directly from the command for a one time run (e.g. when dev server is enabled in the config):
```console
quarkus dev -Dquarkus.quinoa.dev-server=false
```
 