### PR TITLE
Add a warning about the required presence of a src/main directory

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -91,6 +91,8 @@ If not yet created by the tooling, you will need  a Web UI directory in `src/mai
 quarkus.quinoa.ui-dir=../my-webui
 ----
 
+WARNING: Currently, for technical reasons, Quinoa checks for the presence of a `src/main` directory to define which path `quarkus.quinoa.ui-dir` is relative to. If you are introducing Quinoa to an existing web project which has no `src/main` directory, it is recommended to either relocate your web project files to follow Quinoa conventions or add your Quarkus project (that has a `src/main` directory) to a subdirectory of your existing web project.
+
 From here, copy your existing Web UI or generate an application from any existing Node based Web UI framework such as <<react>>, <<angular>>, Lit, Webpack, Rollup, ... or your own. Example:
 
 


### PR DESCRIPTION
Following the discussion in #215, I think a doc warning should be enough to solve the issue currently. As english is not my first language, I please ask if the wording I used here would be appropriate to address the issue.

Should we also add a hint to the logger about the `src/main` check?

Also, is there interest in adding the absolute path check pointed in https://github.com/quarkiverse/quarkus-quinoa/issues/215#issuecomment-1337558133 ? if yes I could implement it.

