### PR TITLE
Allow Quinoa to work even if the project root is not found

### DIFF
--- a/deployment-testing/src/main/java/io/quarkiverse/quinoa/deployment/testing/QuinoaQuarkusUnitTest.java
+++ b/deployment-testing/src/main/java/io/quarkiverse/quinoa/deployment/testing/QuinoaQuarkusUnitTest.java
@@ -49,6 +49,10 @@ public class QuinoaQuarkusUnitTest {
         return new QuinoaQuarkusUnitTest(getWebUITestDirPath(name));
     }
 
+    public static QuinoaQuarkusUnitTest create(Path uiDir) {
+        return new QuinoaQuarkusUnitTest(uiDir);
+    }
+
     public QuinoaQuarkusUnitTest initialLockfile(LockFile lockFile) {
         this.initialLockfile = lockFile.getFileName();
         return this;
@@ -108,6 +112,7 @@ public class QuinoaQuarkusUnitTest {
         final Path webUI = Path.of("src/test/webui/");
         try {
             FileUtil.deleteDirectory(testDir);
+            Files.createDirectories(testDir);
             copyDirectory(webUI, testDir);
             if (nodeModules) {
                 Files.createDirectory(testDir.resolve("node_modules"));

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/PackageManagerInstallConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/PackageManagerInstallConfig.java
@@ -9,6 +9,8 @@ import io.quarkus.runtime.annotations.ConfigItem;
 @ConfigGroup
 public class PackageManagerInstallConfig {
 
+    private static final String DEFAULT_INSTALL_DIR = ".quinoa/";
+
     /**
      * Enable Package Manager Installation.
      * This will override "package-manager" config.
@@ -23,7 +25,7 @@ public class PackageManagerInstallConfig {
      * it will be installed in a node/ sub-directory.
      * Default is ${project.root}/.quinoa
      */
-    @ConfigItem(defaultValue = ".quinoa/")
+    @ConfigItem(defaultValue = DEFAULT_INSTALL_DIR)
     public String installDir;
 
     /**

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaAbsoluteUIDirTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaAbsoluteUIDirTest.java
@@ -1,0 +1,52 @@
+package io.quarkiverse.quinoa.test;
+
+import static io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest.isWindows;
+import static io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest.systemBinary;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class QuinoaAbsoluteUIDirTest {
+    private static final String NAME = "test-webui-absolute-dir";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create(getUIDir().resolve("webui")).toQuarkusUnitTest()
+            .overrideConfigKey("quarkus.package.output-directory", getUIDir().resolve("target").toAbsolutePath().toString())
+            .assertLogRecords(l -> {
+                assertThat(l)
+                        .anyMatch(s -> s.getMessage().equals("Running Quinoa package manager build command: %s") &&
+                                s.getParameters()[0].equals(systemBinary("npm") + " run build"));
+                assertThat(l)
+                        .anyMatch(s -> s.getMessage().equals("Quinoa is ignoring paths starting with: /q/"));
+            });
+
+    static {
+        try {
+            Files.createDirectories(getUIDir().resolve("target"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testQuinoa() {
+        assertThat(getUIDir().resolve(Path.of("target/quinoa-build/index.html"))).isRegularFile()
+                .hasContent("test");
+        assertThat(getUIDir().resolve("webui").resolve("node_modules/installed")).isRegularFile()
+                .hasContent("hello");
+    }
+
+    private static Path getUIDir() {
+        final Path tmpDir = isWindows() ? Path.of("C:/Temp") : Path.of("/tmp");
+        return tmpDir.resolve(NAME);
+    }
+
+}

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerInstallPrependBinaryTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerInstallPrependBinaryTest.java
@@ -36,6 +36,8 @@ public class QuinoaPackageManagerInstallPrependBinaryTest {
                 .hasContent("yeahhh");
         assertThat(getWebUITestDirPath(NAME).resolve("node_modules/installed")).isRegularFile()
                 .hasContent("hello");
+        assertThat(Path.of("target/node-" + NAME)).isDirectory();
+        assertThat(Path.of("target/node-" + NAME + "/node")).isDirectory();
     }
 
     private static String convertToWindowsPathIfNeeded(String path) {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerInstallTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPackageManagerInstallTest.java
@@ -33,6 +33,8 @@ public class QuinoaPackageManagerInstallTest {
                 .hasContent("test");
         assertThat(getWebUITestDirPath(NAME).resolve("node_modules/installed")).isRegularFile()
                 .hasContent("hello");
+        assertThat(Path.of("target/node-" + NAME)).isDirectory();
+        assertThat(Path.of("target/node-" + NAME + "/node")).isDirectory();
     }
 
     private static String convertToWindowsPathIfNeeded(String path) {


### PR DESCRIPTION
Fixes #215 

It is now possible for Quinoa to work even if the project root dir is not found. 
To make it work:
- The `ui-dir` must be absolute
- In `package-manager-install=true` mode, the install-dir must also be absolute