### PR TITLE
Quinoa can work without a src dir

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -280,8 +280,10 @@ public class QuinoaProcessor {
     static Path findProjectRoot(Path outputDirectory) {
         Path currentPath = outputDirectory;
         do {
-            Path toCheck = currentPath.resolve(Paths.get("src", "main"));
-            if (toCheck.toFile().exists()) {
+            if (Files.exists(currentPath.resolve(Paths.get("src", "main")))
+                    || Files.exists(currentPath.resolve(Paths.get("config", "application.properties")))
+                    || Files.exists(currentPath.resolve(Paths.get("config", "application.yaml")))
+                    || Files.exists(currentPath.resolve(Paths.get("config", "application.yml")))) {
                 return currentPath;
             }
             if (currentPath.getParent() != null && Files.exists(currentPath.getParent())) {


### PR DESCRIPTION
Related to #215 

Now the root project dir can be detected if one of those exists:
- src/main
- config/application.properties
- config/application.yml
- config/application.yaml

Thanks to this, projects without a `src` dir, but instead a `webui` and a `config/application.properties` can work out of the box.
