### PR TITLE
Fix host ipv6

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/DevServerConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/DevServerConfig.java
@@ -34,6 +34,12 @@ public class DevServerConfig {
     public OptionalInt port;
 
     /**
+     * Host of the server to forward requests to.
+     * By default, Quinoa will use the host contained in the request headers.
+     */
+    public Optional<String> host;
+
+    /**
      * After start, Quinoa wait for the external dev server.
      * by sending GET requests to this path waiting for a 200 status.
      *

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevServerBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevServerBuildItem.java
@@ -4,10 +4,16 @@ import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class ForwardedDevServerBuildItem extends SimpleBuildItem {
 
+    private final String host;
     private final Integer port;
 
-    public ForwardedDevServerBuildItem(Integer port) {
+    public ForwardedDevServerBuildItem(String host, Integer port) {
+        this.host = host;
         this.port = port;
+    }
+
+    public String getHost() {
+        return host;
     }
 
     public Integer getPort() {

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,5 +1,5 @@
-:quarkus-version: 3.0.0.Alpha6
-:quarkus-quinoa-version: 1.2.6
+:quarkus-version: 2.16.4.Final
+:quarkus-quinoa-version: 1.2.7
 :maven-version: 3.8.1+
 
 :quarkus-org-url: https://github.com/quarkusio

--- a/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
@@ -410,6 +410,20 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.dev-server.host]]`link:#quarkus-quinoa_quarkus.quinoa.dev-server.host[quarkus.quinoa.dev-server.host]`
+
+[.description]
+--
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_DEV_SERVER_HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_QUINOA_DEV_SERVER_HOST+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.dev-server.check-path]]`link:#quarkus-quinoa_quarkus.quinoa.dev-server.check-path[quarkus.quinoa.dev-server.check-path]`
 
 [.description]

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java
@@ -7,6 +7,7 @@ import static io.quarkiverse.quinoa.QuinoaRecorder.resolvePath;
 import static io.quarkiverse.quinoa.QuinoaRecorder.shouldHandleMethod;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.jboss.logging.Logger;
 
@@ -29,16 +30,19 @@ class QuinoaDevProxyHandler implements Handler<RoutingContext> {
             HttpHeaders.CONTENT_RANGE.toString(),
             HttpHeaders.CONTENT_LENGTH.toString(),
             HttpHeaders.CONTENT_TYPE.toString());
+
+    private final Optional<String> host;
     private final int port;
     private final WebClient client;
     private final QuinoaDevWebSocketProxyHandler wsUpgradeHandler;
     private final ClassLoader currentClassLoader;
     private final QuinoaHandlerConfig config;
 
-    QuinoaDevProxyHandler(final QuinoaHandlerConfig config, final Vertx vertx, int port, boolean websocket) {
+    QuinoaDevProxyHandler(final QuinoaHandlerConfig config, final Vertx vertx, String host, int port, boolean websocket) {
+        this.host = Optional.ofNullable(host);
         this.port = port;
         this.client = WebClient.create(vertx);
-        this.wsUpgradeHandler = websocket ? new QuinoaDevWebSocketProxyHandler(vertx, port) : null;
+        this.wsUpgradeHandler = websocket ? new QuinoaDevWebSocketProxyHandler(vertx, host, port) : null;
         this.config = config;
         currentClassLoader = Thread.currentThread().getContextClassLoader();
     }
@@ -88,7 +92,7 @@ class QuinoaDevProxyHandler implements Handler<RoutingContext> {
         headers.remove("Accept");
         // Disable compression in the forwarded request
         headers.remove("Accept-Encoding");
-        client.request(request.method(), port, request.localAddress().host(), uri)
+        client.request(request.method(), port, host.orElseGet(() -> computeHostName(request)), uri)
                 .putHeaders(headers)
                 .send(event -> {
                     if (event.succeeded()) {
@@ -107,6 +111,14 @@ class QuinoaDevProxyHandler implements Handler<RoutingContext> {
                         error(event, ctx);
                     }
                 });
+    }
+
+    static String computeHostName(HttpServerRequest request) {
+        final String[] split = request.host().split(":");
+        if (split.length == 0) {
+            throw new IllegalStateException("Invalid host: " + request.host());
+        }
+        return split[0];
     }
 
     private String computeResourceURI(String path, HttpServerRequest request) {

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
@@ -26,9 +26,9 @@ public class QuinoaRecorder {
     public static final Set<HttpMethod> HANDLED_METHODS = Set.of(HttpMethod.HEAD, HttpMethod.OPTIONS, HttpMethod.GET);
 
     public Handler<RoutingContext> quinoaProxyDevHandler(final QuinoaHandlerConfig handlerConfig, Supplier<Vertx> vertx,
-            int port, boolean websocket) {
+            String host, int port, boolean websocket) {
         logIgnoredPathPrefixes(handlerConfig.ignoredPathPrefixes);
-        return new QuinoaDevProxyHandler(handlerConfig, vertx.get(), port, websocket);
+        return new QuinoaDevProxyHandler(handlerConfig, vertx.get(), host, port, websocket);
     }
 
     public Handler<RoutingContext> quinoaSPARoutingHandler(final QuinoaHandlerConfig handlerConfig) throws IOException {


### PR DESCRIPTION
- Introduce `quarkus.quinoa.dev-server.host` which is optional and allow to configure the host for the dev-server.
- By default the host will be resolved from the host contained in the request headers (before it was using `localAddress.host()` which might be causing the ipv6 problem on some system)

Fixes #266 