### PR TITLE
Change "preview" to "stable"

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -19,7 +19,7 @@ metadata:
   guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-quinoa/dev/index.html
   categories:
     - "web"
-  status: "preview"
+  status: "stable"
   codestart:
     name: "quinoa"
     languages:


### PR DESCRIPTION
Its been a couple of years I think its safe to remove the Preview label.

![image](https://github.com/quarkiverse/quarkus-quinoa/assets/4399574/131fcef7-3993-42d9-9a16-ee05d6ac2b5f)
