### PR TITLE
Plus sign look better in dark/light theme

### DIFF
--- a/docs/modules/ROOT/assets/images/plus-sign.svg
+++ b/docs/modules/ROOT/assets/images/plus-sign.svg
@@ -59,7 +59,7 @@
      inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="font-size:431.92422485px;font-style:normal;font-weight:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:Bitstream Vera Sans"
+       style="font-size:431.92422485px;font-style:normal;font-weight:normal;fill:dimgray;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:Bitstream Vera Sans"
        d="M 241.99219,407.91016 L 241.99219,310.44922 L 144.72656,310.44922 L 144.72656,294.43359 L 241.99219,294.43359 L 241.99219,197.36328 L 257.61719,197.36328 L 257.61719,294.43359 L 355.27344,294.43359 L 355.27344,310.44922 L 257.61719,310.44922 L 257.61719,407.91016 L 241.99219,407.91016 z"
        id="text2464" />
   </g>


### PR DESCRIPTION
 This makes the + sign on the ReadME look better in both light and dark theme