### PR TITLE
Fix #397: Vite detect server port in vite.config.js

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -250,13 +250,11 @@ public class QuinoaProcessor {
             return new QuinoaDirectoryBuildItem(packageManager, "start", port, buildDirectory);
         }
 
-        LOG.infof("%s", packageManager.getPackageManagerCommands());
-
         // only override properties that have not been set
         FrameworkType framework = detectedFramework.getFrameworkType();
         if (launchMode.getLaunchMode() != LaunchMode.NORMAL && port.isEmpty()) {
-            LOG.infof("%s framework setting dev server port: %d", framework, framework.getDevServerPort());
-            port = OptionalInt.of(framework.getDevServerPort());
+            LOG.infof("%s framework setting dev server port: %d", framework, detectedFramework.getDevServerPort());
+            port = OptionalInt.of(detectedFramework.getDevServerPort());
             LOG.infof("%s framework setting dev script: '%s'", framework, detectedFramework.getDevServerCommand());
         }
 

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,5 +1,5 @@
 :quarkus-version: 3.1.0.Final
-:quarkus-quinoa-version: 2.0.4
+:quarkus-quinoa-version: 2.0.5
 :maven-version: 3.8.1+
 
 :quarkus-org-url: https://github.com/quarkusio


### PR DESCRIPTION
Fix #397: Vite detect server port in vite.config.js

Here is a SolidJS example script...
```js
export default defineConfig({
  plugins: [
    /* 
    Uncomment the following line to enable solid-devtools.
    For more info see https://github.com/thetarnav/solid-devtools/tree/main/packages/extension#readme
    */
    // devtools(),
    solidPlugin(),
  ],
  server: {
    port: 3000,
  },
  build: {
    target: 'esnext',
  },
});
```


Here is what happens now...

```
 VITE framework automatically detected from package.json file.
 VITE framework found port override in 'vite.config.js': 3000
 VITE framework setting dev server port: 3000
 VITE framework setting dev script: 'dev'
 VITE framework setting build directory: 'dist'
Quinoa package manager live coding is up and running on port: 3000 (in 534ms)
Quinoa is forwarding unhandled requests to port: 3000
```