### PR TITLE
Fix all asciidoc warnings by using pass macro

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -163,7 +163,7 @@ quarkus.quinoa.package-manager-install.node-version=18.16.0 <2>
 <1> Enable package manager install
 <2> Define the version of NodeJS to install
 
-NOTE: By default, NodeJS and NPM will be installed in `{project-dir}/.quinoa/` (can be link:#quarkus-quinoa_quarkus.quinoa.package-manager-install.install-dir[configured]). If not specified, it will use the NPM version provided by NodeJS.
+NOTE: By default, NodeJS and NPM will be installed in `pass:[{project-dir}]/.quinoa/` (can be link:#quarkus-quinoa_quarkus.quinoa.package-manager-install.install-dir[configured]). If not specified, it will use the NPM version provided by NodeJS.
 
 If NodeJS and NPM are not installed by Quinoa, it is possible to override the package manager (NPM, Yarn or PNPM), otherwise, it will be auto-detected depending on the project lockfile (NPM is the fallback):
 
@@ -197,7 +197,7 @@ By default, the following commands and environment variables are used in the dif
 
 *Build:*
 
-`(npm|pnpm|yarn) run build`, with environment `MODE=${mode}` (https://quarkus.io/guides/lifecycle#launch-modes[`dev`, `test` or `prod`])
+`(npm|pnpm|yarn) run build`, with environment `MODE=pass:[${mode}]` (https://quarkus.io/guides/lifecycle#launch-modes[`dev`, `test` or `prod`])
 
 *Test:*
 


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Describe your changes

Asciidoc interprets strings like ${project-dir} as attributes and then issues a WARN during the build that it will skip reference to a missing attribute. This commit uses inline pass macro to tell asciidoc that enclosed content should be excluded from all substitutions.

Proof of all warnings gone:
<img width="906" alt="image" src="https://github.com/quarkiverse/quarkus-quinoa/assets/11942401/caa36972-8cac-47a0-a69a-bf5349b1a748">

Proof of warnings before this PR:
<img width="764" alt="image" src="https://github.com/quarkiverse/quarkus-quinoa/assets/11942401/90366496-e748-418e-82b7-6c9203e7398c">



<!--  If your PR fixes an open issue then use Closes #31 -->
## Fixes Issue

 
## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
