### PR TITLE
replaceAll() method instead of the replace()

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaUIResourceHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaUIResourceHandler.java
@@ -87,12 +87,12 @@ class QuinoaUIResourceHandler implements Handler<RoutingContext> {
         }
 
         return URLEncoder.encode(string, StandardCharsets.UTF_8)
-                .replace("+", "%20")
-                .replace("%21", "!")
-                .replace("%27", "'")
-                .replace("%28", "(")
-                .replace("%29", ")")
-                .replace("%2F", "/")
-                .replace("%7E", "~");
+                .replaceAll("+", "%20")
+                .replaceAll("%21", "!")
+                .replaceAll("%27", "'")
+                .replaceAll("%28", "(")
+                .replaceAll("%29", ")")
+                .replaceAll("%2F", "/")
+                .replaceAll("%7E", "~");
     }
 }


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Describe your changes
The `replace()` method only replaces the first occurrence of a pattern in a string, while the `replaceAll()` method replaces all occurrences of the pattern.
<!--  If your PR fixes an open issue then use Closes #31 -->
## Fixes Issue

 
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--

[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done -->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
