### PR TITLE
Fix #506: Yarn issues on Windows

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/types/PackageManagerType.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/types/PackageManagerType.java
@@ -10,7 +10,7 @@ public enum PackageManagerType {
     // Order matters for detection
     PNPM("pnpm", "pnpm-lock.yaml", "install --frozen-lockfile"),
     NPM("npm", "package-lock.json", "ci"),
-    YARN("yarn", "yarn.lock", "install --frozen-lockfile"),
+    YARN("yarn", "yarn.lock", "install --immutable"),
     ;
 
     private static final Map<String, PackageManagerType> TYPES = Arrays.stream(values()).sequential()

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaCIConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaCIConfigTest.java
@@ -1,7 +1,6 @@
 package io.quarkiverse.quinoa.test;
 
 import static io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest.getWebUITestDirPath;
-import static io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest.systemBinary;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -21,10 +20,13 @@ public class QuinoaCIConfigTest {
             .ci(null)
             .toQuarkusUnitTest()
             .overrideConfigKey("quarkus.quinoa.ci", "true")
+            .assertException(e -> {
+                assertThat(e)
+                        .hasMessage("Error in Quinoa while running package manager ci command: yarn.cmd install --immutable");
+            })
             .assertLogRecords(l -> assertThat(l)
-                    .anyMatch(s -> s.getMessage().equals("Running Quinoa package manager ci command: %s") &&
-                            s.getParameters()[0].equals(
-                                    systemBinary(PackageManagerType.YARN.getBinary()) + " install --frozen-lockfile")));
+                    .anyMatch(s -> s.getMessage().contains(
+                            "The lockfile would have been modified by this install, which is explicitly forbidden.")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/webui/.yarnrc.yml
+++ b/deployment/src/test/webui/.yarnrc.yml
@@ -1,0 +1,2 @@
+nodeLinker: node-modules
+enableImmutableInstalls: false

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,5 +1,5 @@
 :quarkus-version: 3.2.6.Final
-:quarkus-quinoa-version: 2.2.0.CR2
+:quarkus-quinoa-version: 2.2.0.CR3
 :maven-version: 3.8.1+
 :extension-status: stable
 


### PR DESCRIPTION
attempting to fix all the Yarn issues on Windows.

`--frozen-lock-file` is deprecated it is now `--immutable`