### PR TITLE
Fix 404 to Quinoa package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Read the full [Quinoa documentation](https://docs.quarkiverse.io/quarkus-quinoa/
 
 - Create or use an existing Quarkus application
 - Add the Quinoa extension
-- Install [NodeJS](https://nodejs.org/) or make sure Quinoa is [configured](https://docs.quarkiverse.io/quarkus-quinoa/dev/index.html#package-manager) to install it.
+- Install [NodeJS](https://nodejs.org/) or make sure Quinoa is [configured](https://docs.quarkiverse.io/quarkus-quinoa/dev/advanced-guides.html#package-manager) to install it.
 
 ### Installation
 


### PR DESCRIPTION
This PR attempts to fix the link to configure Quinoa to install nodejs. Based on the original link, this is my best guest. If it is not the correct address then consider this a roundabout way of raising the issue ^^