### PR TITLE
Update advanced-guides.adoc

### DIFF
--- a/docs/modules/ROOT/pages/advanced-guides.adoc
+++ b/docs/modules/ROOT/pages/advanced-guides.adoc
@@ -147,8 +147,8 @@ WARNING: Currently, for technical reasons, the Quinoa SPA routing configuration 
 ----
 @ApplicationScoped
 public class SPARouting {
-    private static final String[] PATH_PREFIXES = { "/api/", "/q/" };
-    private static final Predicate<String> FILE_NAME_PREDICATE = Pattern.compile(".*[.][a-zA-Z\\d]+").asMatchPredicate();
+    private static final String[] PATH_PREFIXES = {"/q/", "/api/", "/@"};
+    private static final Predicate<String> FILE_NAME_PREDICATE = Pattern.compile(".+\\.[a-zA-Z0-9]+$").asMatchPredicate();
 
     public void init(@Observes Router router) {
         router.get("/*").handler(rc -> {


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Describe your changes

testing using Vite I realized that it was not allowing boomarkable URLs to my app location `/app`

Working with @ia3andy we realized these two values needed to change

1. Add `/@` because Vite requests two things `/@vite/client` and `/@reactrefresh` which were being blocked by default.
2. The file regex URL needed to be tweaked.