### PR TITLE
Use xref instead of link for internal documentation links

### DIFF
--- a/docs/modules/ROOT/pages/advanced-guides.adoc
+++ b/docs/modules/ROOT/pages/advanced-guides.adoc
@@ -4,7 +4,7 @@
 == How to use the extension.
 
 === Configure the build
-Add a `build` script in the `package.json` to generate your web application index.html, scripts and assets (styles, images, ...) in some `build` directory (configurable link:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.build-dir[Build Dir]).
+Add a `build` script in the `package.json` to generate your web application index.html, scripts and assets (styles, images, ...) in some `build` directory (configurable xref:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.build-dir[Build Dir]).
 [source,json]
 ----
  "scripts": {
@@ -46,7 +46,7 @@ quarkus.quinoa.package-manager-install.npm-version=10.1.0 <3>
 <2> Define the version of NodeJS to install
 <3> Define the version of NPM to install
 
-NOTE: By default, NodeJS and NPM will be installed in `pass:[{project-dir}]/.quinoa/` (can be link:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.package-manager-install.install-dir[configured]). If not specified, it will use the NPM version provided by NodeJS.
+NOTE: By default, NodeJS and NPM will be installed in `pass:[{project-dir}]/.quinoa/` (can be xref:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.package-manager-install.install-dir[configured]). If not specified, it will use the NPM version provided by NodeJS.
 
 If NodeJS and NPM are not installed by Quinoa, it is possible to override the package manager (NPM, Yarn or PNPM), otherwise, it will be auto-detected depending on the project lockfile (NPM is the fallback):
 
@@ -94,7 +94,7 @@ By default, the following commands and environment variables are used in the dif
 === Override package manager commands
 
 By default, Quinoa uses sensible default commands when executing the different phases, `install`, `build`, `test`, `dev`.
-It is possible to override one or more of them from the link:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.package-manager-command.install[package manager command configuration]:
+It is possible to override one or more of them from the xref:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.package-manager-command.install[package manager command configuration]:
 
 [source,properties]
 ----
@@ -104,7 +104,7 @@ quarkus.quinoa.package-manager-command.build-env.BUILD=value # <2>
 
 <1> This makes `npm ci --cache $CACHE_DIR/.npm --prefer-offline` the command executed in the `install` phase.
 (overriding `quarkus.quinoa.package-manager` and `quarkus.quinoa.frozen-lockfile=true`).
-<2> set environment variable `BUILD` with value `value`. Environment variables set in config can be added to the  link:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.package-manager-command.build-env-build-env[listed commands].
+<2> set environment variable `BUILD` with value `value`. Environment variables set in config can be added to the  xref:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.package-manager-command.build-env-build-env[listed commands].
 
 WARNING: Using custom commands will override `quarkus.quinoa.package-manager` and `quarkus.quinoa.frozen-lockfile`.
 
@@ -125,7 +125,7 @@ To enable the UI live-coding dev server, set a `start` script and set the port i
 quarkus.quinoa.dev-server.port=3000
 ----
 
-NOTE: Quinoa relies on the dev server returning a 404 when the file is not found (See link:main-concepts.adoc#how-dev-server[How it works]). This is not the case on some dev servers configured with SPA routing. Make sure it is disabled in the dev server configuration (for React Create App, see https://github.com/quarkiverse/quarkus-quinoa/issues/91[#91]). Another option, when possible, is to use link:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.ignored-path-prefixes[Ignored Path Prefixes].
+NOTE: Quinoa relies on the dev server returning a 404 when the file is not found (See xref:main-concepts.adoc#how-dev-server[How it works]). This is not the case on some dev servers configured with SPA routing. Make sure it is disabled in the dev server configuration (for React Create App, see https://github.com/quarkiverse/quarkus-quinoa/issues/91[#91]). Another option, when possible, is to use xref:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.ignored-path-prefixes[Ignored Path Prefixes].
 
 [#spa-routing]
 === Single Page application routing
@@ -197,8 +197,6 @@ quarkus.http.enable-compression=true
 
 Most CI images already include NodeJS. if they don't, just make sure to install it alongside Maven/Gradle (and Yarn/PNPM if needed). Then you can use it like any Maven/Gradle project.
 
-Quinoa can be configured to install packages with a link:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.frozen-lockfile[frozen lockfile].
+Quinoa can be configured to install packages with a xref:config-reference.adoc#quarkus-quinoa_quarkus.quinoa.frozen-lockfile[frozen lockfile].
 
 On compatible CIs, don't forget to enable the Maven/Gradle and NPM/Yarn repository caching.
-
-

--- a/docs/modules/ROOT/pages/main-concepts.adoc
+++ b/docs/modules/ROOT/pages/main-concepts.adoc
@@ -8,7 +8,7 @@ include::./includes/attributes.adoc[]
 
 image::quinoa-build.png[Quinoa Build]
 
-NOTE: packages are installed by Quinoa before the build when needed (i.e `npm install`). See link:#install-packages[Packages installation]. Quinoa is pre-configured to work with your favorite link:#package-manager[package manager] (npm, yarn or pnpm).
+NOTE: packages are installed by Quinoa before the build when needed (i.e `npm install`). See xref:advanced-guides.adoc#install-packages[Packages installation]. Quinoa is pre-configured to work with your favorite xref:advanced-guides.adoc#package-manager[package manager] (npm, yarn or pnpm).
 
 === Runtime for production mode
 
@@ -20,7 +20,7 @@ image::quinoa-runtime-prod.png[Quinoa Runtime Production]
 
 Quinoa (using Quarkus live-coding watch feature) will watch the Web UI directory and trigger a new build on changes. It works the same as the production mode. This option is perfect for small/fast builds.
 
-NOTE: You can differentiate the build for link:#build-mode[dev mode]. e.g to disable minification.
+NOTE: You can differentiate the build for xref:advanced-guides.adoc#build-mode[dev mode]. e.g to disable minification.
 
 [#how-dev-server]
 === Runtime for proxied live-coding
@@ -31,4 +31,4 @@ image::quinoa-proxy-dev.png[Quinoa Proxy Dev]
 
 NOTE: Quarkus live-coding will keep watching for the backend changes as usual.
 
-See link:#dev-server[Enable the proxied live coding].
+See xref:advanced-guides.adoc#dev-server[Enable the proxied live coding].


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Describe your changes
I've noticed that a lot of the internal documentation links are broken. 

According to the [AsciiDoc documentation](https://docs.asciidoctor.org/asciidoc/latest/macros/inter-document-xref/) we are supposed to use `xref:` instead of `link:` for this kinds of links.