### PR TITLE
Revert Vite ignore of /@

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
@@ -137,11 +137,6 @@ public interface QuinoaConfig {
             readExternalConfigPath(allConfig, "quarkus.resteasy.path").ifPresent(defaultIgnore::add);
             readExternalConfigPath(allConfig, "quarkus.resteasy-reactive.path").ifPresent(defaultIgnore::add);
             readExternalConfigPath(allConfig, "quarkus.http.non-application-root-path").ifPresent(defaultIgnore::add);
-
-            // Vite in dev mode requests /@vite/client and /@reactrefresh
-            if (isDevServerMode(config)) {
-                defaultIgnore.add("/@");
-            }
             return defaultIgnore;
         }).stream().map(s -> s.startsWith("/") ? s : "/" + s).collect(toList());
     }


### PR DESCRIPTION
 @ia3andy this broke vite in my local testing it causes those `/@` values to throw error in the browser of "invalid mime type" so if I remove this vite goes back to working.