### PR TITLE
Smart bypass of the dev server SPA

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/DevServerConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/DevServerConfig.java
@@ -74,6 +74,19 @@ public interface DevServerConfig {
     @ConfigDocDefault("auto-detected falling back to the quinoa.index-page")
     Optional<String> indexPage();
 
+    /**
+     * Quinoa deals with SPA routing by itself (see quarkus.quinoa.enable-spa-routing), some dev-server have this feature
+     * enabled by default.
+     * This is a problem for proxying as it prevents other Quarkus resources (REST, ...) to answer.
+     * By default, Quinoa will try to detect when the dev server is answering with a html page for non-existing resources
+     * (SPA-Routing)
+     * in which case it will instead allow other Quarkus resources (REST, ...) to answer.
+     * Set this to true (direct) when the other Quarkus resources use a specific path prefix (and marked as ignored by Quinoa)
+     * or if the dev-server is configured without SPA routing.
+     */
+    @WithDefault("false")
+    boolean directForwarding();
+
     static boolean isEqual(DevServerConfig d1, DevServerConfig d2) {
         if (!Objects.equals(d1.enabled(), d2.enabled())) {
             return false;
@@ -100,6 +113,9 @@ public interface DevServerConfig {
             return false;
         }
         if (!Objects.equals(d1.indexPage(), d2.indexPage())) {
+            return false;
+        }
+        if (!Objects.equals(d1.directForwarding(), d2.directForwarding())) {
             return false;
         }
         return true;

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
@@ -147,7 +147,7 @@ public interface QuinoaConfig {
         final String indexPage = !isDevServerMode(config) ? config.indexPage()
                 : config.devServer().indexPage().orElse(config.indexPage());
         return new QuinoaHandlerConfig(getNormalizedIgnoredPathPrefixes(config), indexPage, prodMode,
-                httpBuildTimeConfig.enableCompression, compressMediaTypes);
+                httpBuildTimeConfig.enableCompression, compressMediaTypes, config.devServer().directForwarding());
     }
 
     private static Optional<String> readExternalConfigPath(Config config, String key) {

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/delegate/DevServerConfigDelegate.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/delegate/DevServerConfigDelegate.java
@@ -55,4 +55,9 @@ public class DevServerConfigDelegate implements DevServerConfig {
     public Optional<String> indexPage() {
         return delegate.indexPage();
     }
+
+    @Override
+    public boolean directForwarding() {
+        return delegate.directForwarding();
+    }
 }

--- a/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
@@ -622,6 +622,23 @@ endif::add-copy-button-to-env-var[]
 |`auto-detected falling back to the quinoa.index-page`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.dev-server.direct-forwarding]]`link:#quarkus-quinoa_quarkus.quinoa.dev-server.direct-forwarding[quarkus.quinoa.dev-server.direct-forwarding]`
+
+
+[.description]
+--
+Quinoa deals with SPA routing by itself (see quarkus.quinoa.enable-spa-routing), some dev-server have this feature enabled by default. This is a problem for proxying as it prevents other Quarkus resources (REST, ...) to answer. By default, Quinoa will try to detect when the dev server is answering with a html page for non-existing resources (SPA-Routing) in which case it will instead allow other Quarkus resources (REST, ...) to answer. Set this to true (direct) when the other Quarkus resources use a specific path prefix (and marked as ignored by Quinoa) or if the dev-server is configured without SPA routing.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_DEV_SERVER_DIRECT_FORWARDING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_QUINOA_DEV_SERVER_DIRECT_FORWARDING+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.package-manager-command.install-env-install-env]]`link:#quarkus-quinoa_quarkus.quinoa.package-manager-command.install-env-install-env[quarkus.quinoa.package-manager-command.install-env]`
 
 

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,5 +1,6 @@
-%root-path.quarkus.http.root-path=/foo/bar
-%root-path.quarkus.quinoa.enable-spa-routing=true
+%lit-root-path.quarkus.http.root-path=/foo/bar
+%lit-root-path.quarkus.quinoa.enable-spa-routing=true
+%lit-root-path.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/foo/bar/
 
 %react.quarkus.quinoa.ui-dir=src/main/ui-react
 %vue.quarkus.quinoa.ui-dir=src/main/ui-vue
@@ -11,12 +12,14 @@
 %angular.quarkus.quinoa.package-manager-install.install-dir=target/
 %angular.quarkus.quinoa.package-manager-install.node-version=20.9.0
 %angular.quarkus.quinoa.package-manager-install.yarn-version=1.22.19
-%lit.quarkus.quinoa.ui-dir=src/main/ui-lit
-%lit.quarkus.quinoa.build-dir=dist
-%lit.quarkus.quinoa.index-page=app.html
-%lit.quarkus.quinoa.package-manager-command.build=run build-per-env
+%lit,lit-root-path.quarkus.quinoa.ui-dir=src/main/ui-lit
+%lit,lit-root-path.quarkus.quinoa.build-dir=dist
+%lit,lit-root-path.quarkus.quinoa.index-page=app.html
+%lit,lit-root-path.quarkus.quinoa.package-manager-command.build=run build-per-env
+%lit-root-path.quarkus.quinoa.package-manager-command.build-env.FOO=bar
 %lit.quarkus.quinoa.package-manager-command.build-env.FOO=bar
 %lit.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/
+
 %yarn.quarkus.quinoa.package-manager=yarn
 %just-build.quarkus.quinoa.just-build=true
 

--- a/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaRootPathTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaRootPathTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.quinoa.it;
 
 import java.net.URL;
 
+import com.microsoft.playwright.ElementHandle;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +40,11 @@ public class QuinoaRootPathTest {
 
         String title = page.title();
         Assertions.assertEquals("Quinoa Lit App", title);
+
+        // Make sure the component loaded and hits the backend
+        final ElementHandle quinoaEl = page.waitForSelector(".greeting");
+        String greeting = quinoaEl.innerText();
+        Assertions.assertEquals("Hello Quinoa and World and bar", greeting);
     }
 
     @Test

--- a/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaRootPathTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaRootPathTest.java
@@ -2,11 +2,11 @@ package io.quarkiverse.quinoa.it;
 
 import java.net.URL;
 
-import com.microsoft.playwright.ElementHandle;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.ElementHandle;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Response;
 

--- a/integration-tests/src/test/java/io/quarkiverse/quinoa/it/TestProfiles.java
+++ b/integration-tests/src/test/java/io/quarkiverse/quinoa/it/TestProfiles.java
@@ -42,7 +42,7 @@ public class TestProfiles {
     public static class RootPathTests extends QuinoaTestProfiles.Enable {
         @Override
         public String getConfigProfile() {
-            return "root-path,lit";
+            return "lit-root-path";
         }
     }
 

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java
@@ -94,7 +94,7 @@ class QuinoaDevProxyHandler implements Handler<RoutingContext> {
                         final int statusCode = event.result().statusCode();
                         switch (statusCode) {
                             case 200:
-                                if (shouldForward(ctx, event.result())) {
+                                if (config.devServerDirectForwarding || shouldForward(ctx, event.result())) {
                                     forwardResponse(event, request, ctx, resourcePath);
                                 } else {
                                     next(currentClassLoader, ctx);

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java
@@ -85,11 +85,6 @@ class QuinoaDevProxyHandler implements Handler<RoutingContext> {
         final MultiMap headers = request.headers();
         final String uri = computeResourceURI(resourcePath, request);
 
-        // Workaround for issue https://github.com/quarkiverse/quarkus-quinoa/issues/91
-        // See
-        // https://www.npmjs.com/package/connect-history-api-fallback#htmlacceptheaders
-        // When no Accept header is provided, the historyApiFallback is disabled
-        headers.remove("Accept");
         // Disable compression in the forwarded request
         headers.remove("Accept-Encoding");
         client.request(request.method(), port, host, uri)
@@ -99,7 +94,12 @@ class QuinoaDevProxyHandler implements Handler<RoutingContext> {
                         final int statusCode = event.result().statusCode();
                         switch (statusCode) {
                             case 200:
-                                forwardResponse(event, request, ctx, resourcePath);
+                                if (shouldForward(ctx, event.result())) {
+                                    forwardResponse(event, request, ctx, resourcePath);
+                                } else {
+                                    next(currentClassLoader, ctx);
+                                }
+
                                 break;
                             case 404:
                                 next(currentClassLoader, ctx);
@@ -111,6 +111,18 @@ class QuinoaDevProxyHandler implements Handler<RoutingContext> {
                         error(event, ctx);
                     }
                 });
+    }
+
+    private boolean shouldForward(RoutingContext ctx, HttpResponse<Buffer> result) {
+        final List<String> contentType = result.headers().getAll(HttpHeaders.CONTENT_TYPE);
+        if (contentType != null && contentType.stream().anyMatch(s -> s.contains("text/html"))) {
+            final String path = QuinoaRecorder.resolvePath(ctx);
+            // We forward if the server returns a html, and it was intended:
+            // - if the path ends with .html
+            // - if the path is empty (root)
+            return path.endsWith(".html") || path.equals("/") || path.isEmpty();
+        }
+        return true;
     }
 
     private String computeResourceURI(String path, HttpServerRequest request) {

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaHandlerConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaHandlerConfig.java
@@ -13,14 +13,17 @@ public class QuinoaHandlerConfig {
     public final boolean enableCompression;
     public final Set<String> compressMediaTypes;
 
+    public final boolean devServerDirectForwarding;
+
     @RecordableConstructor
     public QuinoaHandlerConfig(List<String> ignoredPathPrefixes, String indexPage, boolean prodMode, boolean enableCompression,
-            Set<String> compressMediaTypes) {
+            Set<String> compressMediaTypes, boolean devServerDirectForwarding) {
         this.ignoredPathPrefixes = ignoredPathPrefixes;
         this.indexPage = "/".equals(indexPage) ? "" : indexPage;
         this.prodMode = prodMode;
         this.enableCompression = enableCompression;
         this.compressMediaTypes = compressMediaTypes;
+        this.devServerDirectForwarding = devServerDirectForwarding;
     }
 
     @Override
@@ -31,12 +34,14 @@ public class QuinoaHandlerConfig {
             return false;
         QuinoaHandlerConfig that = (QuinoaHandlerConfig) o;
         return prodMode == that.prodMode && enableCompression == that.enableCompression
+                && devServerDirectForwarding == that.devServerDirectForwarding
                 && Objects.equals(ignoredPathPrefixes, that.ignoredPathPrefixes) && Objects.equals(indexPage, that.indexPage)
                 && Objects.equals(compressMediaTypes, that.compressMediaTypes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ignoredPathPrefixes, indexPage, prodMode, enableCompression, compressMediaTypes);
+        return Objects.hash(ignoredPathPrefixes, indexPage, prodMode, enableCompression, compressMediaTypes,
+                devServerDirectForwarding);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaHandlerConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaHandlerConfig.java
@@ -30,11 +30,13 @@ public class QuinoaHandlerConfig {
         if (o == null || getClass() != o.getClass())
             return false;
         QuinoaHandlerConfig that = (QuinoaHandlerConfig) o;
-        return Objects.equals(ignoredPathPrefixes, that.ignoredPathPrefixes) && Objects.equals(indexPage, that.indexPage);
+        return prodMode == that.prodMode && enableCompression == that.enableCompression
+                && Objects.equals(ignoredPathPrefixes, that.ignoredPathPrefixes) && Objects.equals(indexPage, that.indexPage)
+                && Objects.equals(compressMediaTypes, that.compressMediaTypes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ignoredPathPrefixes, indexPage);
+        return Objects.hash(ignoredPathPrefixes, indexPage, prodMode, enableCompression, compressMediaTypes);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-quinoa/issues/574

Add a new config for this `quarkus.quinoa.dev-server.direct-forwarding` (when true, it forwards without the content-type-check)