### PR TITLE
Fix dev service restart condition

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
@@ -82,7 +82,8 @@ public class ForwardedDevProcessor {
         final PackageManagerRunner packageManagerRunner = installedPackageManager.getPackageManager();
         final String checkPath = resolvedConfig.devServer().checkPath().orElse(null);
         if (devService != null) {
-            boolean shouldShutdownTheBroker = !resolvedConfig.equals(oldConfig)
+
+            boolean shouldShutdownTheBroker = !QuinoaConfig.isEqual(resolvedConfig, oldConfig)
                     || QuinoaProcessor.isPackageJsonLiveReloadChanged(configuredQuinoa, liveReload);
             if (!shouldShutdownTheBroker) {
                 if (devServerConfig.port().isEmpty()) {

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/DevServerConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/DevServerConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.quinoa.deployment.config;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
@@ -72,4 +73,35 @@ public interface DevServerConfig {
      */
     @ConfigDocDefault("auto-detected falling back to the quinoa.index-page")
     Optional<String> indexPage();
+
+    static boolean isEqual(DevServerConfig d1, DevServerConfig d2) {
+        if (!Objects.equals(d1.enabled(), d2.enabled())) {
+            return false;
+        }
+        if (!Objects.equals(d1.managed(), d2.managed())) {
+            return false;
+        }
+        if (!Objects.equals(d1.port(), d2.port())) {
+            return false;
+        }
+        if (!Objects.equals(d1.host(), d2.host())) {
+            return false;
+        }
+        if (!Objects.equals(d1.checkPath(), d2.checkPath())) {
+            return false;
+        }
+        if (!Objects.equals(d1.websocket(), d2.websocket())) {
+            return false;
+        }
+        if (!Objects.equals(d1.checkTimeout(), d2.checkTimeout())) {
+            return false;
+        }
+        if (!Objects.equals(d1.logs(), d2.logs())) {
+            return false;
+        }
+        if (!Objects.equals(d1.indexPage(), d2.indexPage())) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/FrameworkConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/FrameworkConfig.java
@@ -1,10 +1,19 @@
 package io.quarkiverse.quinoa.deployment.config;
 
+import java.util.Objects;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface FrameworkConfig {
+
+    static boolean isEqual(FrameworkConfig f1, FrameworkConfig f2) {
+        if (!Objects.equals(f1.detection(), f2.detection())) {
+            return false;
+        }
+        return true;
+    }
 
     /**
      * When true, the UI Framework will be auto-detected if possible

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/PackageManagerCommandConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/PackageManagerCommandConfig.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.quinoa.deployment.config;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
@@ -74,4 +75,31 @@ public interface PackageManagerCommandConfig {
      */
     Map<String, String> devEnv();
 
+    static boolean isEqual(PackageManagerCommandConfig p1, PackageManagerCommandConfig p2) {
+        if (!Objects.equals(p1.install(), p2.install())) {
+            return false;
+        }
+        if (!Objects.equals(p1.installEnv(), p2.installEnv())) {
+            return false;
+        }
+        if (!Objects.equals(p1.ci(), p2.ci())) {
+            return false;
+        }
+        if (!Objects.equals(p1.ciEnv(), p2.ciEnv())) {
+            return false;
+        }
+        if (!Objects.equals(p1.buildEnv(), p2.buildEnv())) {
+            return false;
+        }
+        if (!Objects.equals(p1.testEnv(), p2.testEnv())) {
+            return false;
+        }
+        if (!Objects.equals(p1.dev(), p2.dev())) {
+            return false;
+        }
+        if (!Objects.equals(p1.devEnv(), p2.devEnv())) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/PackageManagerInstallConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/PackageManagerInstallConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.quinoa.deployment.config;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
@@ -80,4 +81,37 @@ public interface PackageManagerInstallConfig {
     @WithDefault("https://registry.npmjs.org/pnpm/-/")
     String pnpmDownloadRoot();
 
+    static boolean isEqual(PackageManagerInstallConfig p1, PackageManagerInstallConfig p2) {
+        if (!Objects.equals(p1.enabled(), p2.enabled())) {
+            return false;
+        }
+        if (!Objects.equals(p1.installDir(), p2.installDir())) {
+            return false;
+        }
+        if (!Objects.equals(p1.enabled(), p2.enabled())) {
+            return false;
+        }
+        if (!Objects.equals(p1.nodeVersion(), p2.nodeVersion())) {
+            return false;
+        }
+        if (!Objects.equals(p1.npmVersion(), p2.npmVersion())) {
+            return false;
+        }
+        if (!Objects.equals(p1.npmDownloadRoot(), p2.npmDownloadRoot())) {
+            return false;
+        }
+        if (!Objects.equals(p1.nodeDownloadRoot(), p2.nodeDownloadRoot())) {
+            return false;
+        }
+        if (!Objects.equals(p1.yarnVersion(), p2.yarnVersion())) {
+            return false;
+        }
+        if (!Objects.equals(p1.pnpmVersion(), p2.pnpmVersion())) {
+            return false;
+        }
+        if (!Objects.equals(p1.pnpmDownloadRoot(), p2.pnpmDownloadRoot())) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
@@ -164,4 +164,53 @@ public interface QuinoaConfig {
         return config.enabled().orElse(true);
     }
 
+    static boolean isEqual(QuinoaConfig q1, QuinoaConfig q2) {
+        if (!Objects.equals(q1.enabled(), q2.enabled())) {
+            return false;
+        }
+        if (!Objects.equals(q1.justBuild(), q2.justBuild())) {
+            return false;
+        }
+        if (!Objects.equals(q1.uiDir(), q2.uiDir())) {
+            return false;
+        }
+        if (!Objects.equals(q1.buildDir(), q2.buildDir())) {
+            return false;
+        }
+        if (!Objects.equals(q1.packageManager(), q2.packageManager())) {
+            return false;
+        }
+        if (!PackageManagerInstallConfig.isEqual(q1.packageManagerInstall(), q2.packageManagerInstall())) {
+            return false;
+        }
+        if (!PackageManagerCommandConfig.isEqual(q1.packageManagerCommand(), q2.packageManagerCommand())) {
+            return false;
+        }
+        if (!Objects.equals(q1.indexPage(), q2.indexPage())) {
+            return false;
+        }
+        if (!Objects.equals(q1.runTests(), q2.runTests())) {
+            return false;
+        }
+        if (!Objects.equals(q1.ci(), q2.ci())) {
+            return false;
+        }
+        if (!Objects.equals(q1.forceInstall(), q2.forceInstall())) {
+            return false;
+        }
+        if (!FrameworkConfig.isEqual(q1.framework(), q2.framework())) {
+            return false;
+        }
+        if (!Objects.equals(q1.enableSPARouting(), q2.enableSPARouting())) {
+            return false;
+        }
+        if (!Objects.equals(q1.ignoredPathPrefixes(), q2.ignoredPathPrefixes())) {
+            return false;
+        }
+        if (!DevServerConfig.isEqual(q1.devServer(), q2.devServer())) {
+            return false;
+        }
+        return true;
+    }
+
 }


### PR DESCRIPTION
Currently dev mode will restart the dev service every time, significantly increasing hot reload time.

 <!--  Describe your changes below that what did you made change -->

Currently the config does not implement equals, so the equals check is based on object equality and will always result in a restart of the dev service.


