### PR TITLE
[Critical] Make sure the devServer indexPage is only used in dev mode

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
@@ -198,7 +198,7 @@ public class ForwardedDevProcessor {
                 return;
             }
             LOG.infof("Quinoa is forwarding unhandled requests to port: %d", devProxy.get().getPort());
-            final QuinoaHandlerConfig handlerConfig = toHandlerConfig(quinoaConfig, false, httpBuildTimeConfig);
+            final QuinoaHandlerConfig handlerConfig = toHandlerConfig(quinoaConfig, true, httpBuildTimeConfig);
             routes.produce(RouteBuildItem.builder().orderedRoute("/*", QUINOA_ROUTE_ORDER)
                     .handler(recorder.quinoaProxyDevHandler(handlerConfig, vertx.getVertx(), devProxy.get().getHost(),
                             devProxy.get().getPort(),

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -259,7 +259,7 @@ public class QuinoaProcessor {
                 directory = uiResources.get().getDirectory().get().toAbsolutePath().toString();
             }
             final QuinoaHandlerConfig handlerConfig = toHandlerConfig(configuredQuinoa.resolvedConfig(),
-                    !launchMode.getLaunchMode().isDevOrTest(),
+                    launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT,
                     httpBuildTimeConfig);
             resumeOn404.produce(new ResumeOn404BuildItem());
             routes.produce(RouteBuildItem.builder().orderedRoute("/*", QUINOA_ROUTE_ORDER)
@@ -357,7 +357,7 @@ public class QuinoaProcessor {
      * Ignored directories include any that start with DOT "." like ".next" or ".svelte", also "node_modules" and any
      * of the framework build directories.
      *
-     * @param filePath the file path to check
+     * @param relativeFilePath the file path to check
      * @return true if it is a directory that should be scanned for changes, false if it should be ignored
      */
     private static boolean shouldWatch(String relativeFilePath) {

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaHandlerConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaHandlerConfig.java
@@ -9,18 +9,18 @@ import io.quarkus.runtime.annotations.RecordableConstructor;
 public class QuinoaHandlerConfig {
     public final List<String> ignoredPathPrefixes;
     public final String indexPage;
-    public final boolean prodMode;
+    public final boolean devMode;
     public final boolean enableCompression;
     public final Set<String> compressMediaTypes;
 
     public final boolean devServerDirectForwarding;
 
     @RecordableConstructor
-    public QuinoaHandlerConfig(List<String> ignoredPathPrefixes, String indexPage, boolean prodMode, boolean enableCompression,
+    public QuinoaHandlerConfig(List<String> ignoredPathPrefixes, String indexPage, boolean devMode, boolean enableCompression,
             Set<String> compressMediaTypes, boolean devServerDirectForwarding) {
         this.ignoredPathPrefixes = ignoredPathPrefixes;
         this.indexPage = "/".equals(indexPage) ? "" : indexPage;
-        this.prodMode = prodMode;
+        this.devMode = devMode;
         this.enableCompression = enableCompression;
         this.compressMediaTypes = compressMediaTypes;
         this.devServerDirectForwarding = devServerDirectForwarding;
@@ -33,7 +33,7 @@ public class QuinoaHandlerConfig {
         if (o == null || getClass() != o.getClass())
             return false;
         QuinoaHandlerConfig that = (QuinoaHandlerConfig) o;
-        return prodMode == that.prodMode && enableCompression == that.enableCompression
+        return devMode == that.devMode && enableCompression == that.enableCompression
                 && devServerDirectForwarding == that.devServerDirectForwarding
                 && Objects.equals(ignoredPathPrefixes, that.ignoredPathPrefixes) && Objects.equals(indexPage, that.indexPage)
                 && Objects.equals(compressMediaTypes, that.compressMediaTypes);
@@ -41,7 +41,7 @@ public class QuinoaHandlerConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(ignoredPathPrefixes, indexPage, prodMode, enableCompression, compressMediaTypes,
+        return Objects.hash(ignoredPathPrefixes, indexPage, devMode, enableCompression, compressMediaTypes,
                 devServerDirectForwarding);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaUIResourceHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaUIResourceHandler.java
@@ -70,7 +70,7 @@ class QuinoaUIResourceHandler implements Handler<RoutingContext> {
                 : StaticHandler.create(QuinoaRecorder.META_INF_WEB_UI);
         staticHandler.setDefaultContentEncoding(StandardCharsets.UTF_8.name());
         staticHandler.setIndexPage(config.indexPage);
-        staticHandler.setCachingEnabled(config.prodMode);
+        staticHandler.setCachingEnabled(!config.devMode);
         return staticHandler;
     }
 


### PR DESCRIPTION
Fixes #603 

This is a big issue which could affect production on different kind of apps (not only with Next), it should be backported.


**To mitigate this issue:**
- if not set (Optional), the dev server index page name is not used, only Next framework automatically overrides it (leading to the production startup failing). 
- If set (this is a new and not very commonly used config) , then currently the dev server index page name would be used in production leading to either a startup failing or a 404 on the index page