### PR TITLE
Create new config for authentication in VertxFileDownloader

### DIFF
--- a/deployment/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PackageManagerInstallFactory.java
+++ b/deployment/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PackageManagerInstallFactory.java
@@ -14,30 +14,45 @@ public class PackageManagerInstallFactory {
     private final Path installDir;
     private final CacheResolver cacheResolver;
     private final VertxFileDownloader fileDownloader;
+    private final String userName;
+    private final String password;
 
-    public PackageManagerInstallFactory(Vertx vertx, Path uiDir, Path installDir) {
+    public PackageManagerInstallFactory(Vertx vertx, Path uiDir, Path installDir, String userName, String password) {
         this.vertx = vertx;
         this.uiDir = uiDir;
         this.installDir = installDir;
         this.cacheResolver = getDefaultCacheResolver(installDir);
+        this.userName = userName;
+        this.password = password;
         fileDownloader = new VertxFileDownloader(vertx);
     }
 
     public NodeInstaller getNodeInstaller() {
-
-        return new NodeInstaller(this.getInstallConfig(), new DefaultArchiveExtractor(), fileDownloader);
+        NodeInstaller nodeInstaller = new NodeInstaller(this.getInstallConfig(), new DefaultArchiveExtractor(), fileDownloader);
+        nodeInstaller.setUserName(this.userName);
+        nodeInstaller.setPassword(this.password);
+        return nodeInstaller;
     }
 
     public NPMInstaller getNPMInstaller() {
-        return new NPMInstaller(this.getInstallConfig(), new DefaultArchiveExtractor(), fileDownloader);
+        NPMInstaller npmInstaller = new NPMInstaller(this.getInstallConfig(), new DefaultArchiveExtractor(), fileDownloader);
+        npmInstaller.setUserName(this.userName);
+        npmInstaller.setPassword(this.password);
+        return npmInstaller;
     }
 
     public PnpmInstaller getPnpmInstaller() {
-        return new PnpmInstaller(this.getInstallConfig(), new DefaultArchiveExtractor(), fileDownloader);
+        PnpmInstaller pnpmInstaller = new PnpmInstaller(this.getInstallConfig(), new DefaultArchiveExtractor(), fileDownloader);
+        pnpmInstaller.setUserName(this.userName);
+        pnpmInstaller.setPassword(this.password);
+        return pnpmInstaller;
     }
 
     public YarnInstaller getYarnInstaller() {
-        return new YarnInstaller(this.getInstallConfig(), new DefaultArchiveExtractor(), fileDownloader);
+        YarnInstaller yarnInstaller = new YarnInstaller(this.getInstallConfig(), new DefaultArchiveExtractor(), fileDownloader);
+        yarnInstaller.setUserName(this.userName);
+        yarnInstaller.setPassword(this.password);
+        return yarnInstaller;
     }
 
     private NodeExecutorConfig getExecutorConfig() {

--- a/deployment/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/VertxFileDownloader.java
+++ b/deployment/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/VertxFileDownloader.java
@@ -25,7 +25,7 @@ import io.vertx.ext.web.codec.BodyCodec;
 public class VertxFileDownloader implements FileDownloader {
     private static final Logger LOG = Logger.getLogger(VertxFileDownloader.class);
     private final Vertx vertx;
-    private WebClient webClient;
+    private final WebClient webClient;
 
     public VertxFileDownloader(Vertx vertx) {
         this.vertx = vertx;
@@ -51,6 +51,7 @@ public class VertxFileDownloader implements FileDownloader {
                 Files.deleteIfExists(destinationPath);
                 final AsyncFile destinationFile = vertx.fileSystem().openBlocking(destination, new OpenOptions());
                 final Future<HttpResponse<Void>> future = webClient.getAbs(downloadUrl)
+                        .basicAuthentication(userName, password)
                         .expect(ResponsePredicate.SC_SUCCESS)
                         .as(BodyCodec.pipe(destinationFile))
                         .send();

--- a/deployment/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/VertxFileDownloader.java
+++ b/deployment/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/VertxFileDownloader.java
@@ -9,15 +9,15 @@ import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpRequest;
 import org.apache.commons.io.FilenameUtils;
 import org.jboss.logging.Logger;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
 import io.vertx.core.file.OpenOptions;
+import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
@@ -53,7 +53,7 @@ public class VertxFileDownloader implements FileDownloader {
                 Files.deleteIfExists(destinationPath);
                 final AsyncFile destinationFile = vertx.fileSystem().openBlocking(destination, new OpenOptions());
                 final HttpRequest<Buffer> httpRequest = webClient.getAbs(downloadUrl);
-                if(userName != null && password != null) {
+                if (userName != null && password != null) {
                     httpRequest.basicAuthentication(userName, password);
                 }
                 final Future<HttpResponse<Void>> future = httpRequest

--- a/deployment/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/VertxFileDownloader.java
+++ b/deployment/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/VertxFileDownloader.java
@@ -9,6 +9,8 @@ import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
 import org.apache.commons.io.FilenameUtils;
 import org.jboss.logging.Logger;
 
@@ -50,8 +52,11 @@ public class VertxFileDownloader implements FileDownloader {
                 final CountDownLatch latch = new CountDownLatch(1);
                 Files.deleteIfExists(destinationPath);
                 final AsyncFile destinationFile = vertx.fileSystem().openBlocking(destination, new OpenOptions());
-                final Future<HttpResponse<Void>> future = webClient.getAbs(downloadUrl)
-                        .basicAuthentication(userName, password)
+                final HttpRequest<Buffer> httpRequest = webClient.getAbs(downloadUrl);
+                if(userName != null && password != null) {
+                    httpRequest.basicAuthentication(userName, password);
+                }
+                final Future<HttpResponse<Void>> future = httpRequest
                         .expect(ResponsePredicate.SC_SUCCESS)
                         .as(BodyCodec.pipe(destinationFile))
                         .send();

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/PackageManagerInstallAuthConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/PackageManagerInstallAuthConfig.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.quinoa.deployment.config;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface PackageManagerInstallAuthConfig {
+
+    /**
+     * The basic authentication username to use for node download.
+     */
+    Optional<String> username();
+
+    /**
+     * The basic authentication password to use for node download.
+     */
+    Optional<String> password();
+
+    static boolean isEqual(PackageManagerInstallAuthConfig p1, PackageManagerInstallAuthConfig p2) {
+        if (!Objects.equals(p1.username(), p2.username())) {
+            return false;
+        }
+        if (!Objects.equals(p1.password(), p2.password())) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/PackageManagerInstallConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/PackageManagerInstallConfig.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 import io.smallrye.config.WithParentName;
 
 @ConfigGroup
@@ -81,6 +82,12 @@ public interface PackageManagerInstallConfig {
     @WithDefault("https://registry.npmjs.org/pnpm/-/")
     String pnpmDownloadRoot();
 
+    /**
+     * Configuration for installing the package manager authenticated
+     */
+    @WithName("basic-auth")
+    PackageManagerInstallAuthConfig packageManagerInstallAuth();
+
     static boolean isEqual(PackageManagerInstallConfig p1, PackageManagerInstallConfig p2) {
         if (!Objects.equals(p1.enabled(), p2.enabled())) {
             return false;
@@ -110,6 +117,9 @@ public interface PackageManagerInstallConfig {
             return false;
         }
         if (!Objects.equals(p1.pnpmDownloadRoot(), p2.pnpmDownloadRoot())) {
+            return false;
+        }
+        if (!PackageManagerInstallAuthConfig.isEqual(p1.packageManagerInstallAuth(), p2.packageManagerInstallAuth())) {
             return false;
         }
         return true;

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/PackageManagerInstall.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/PackageManagerInstall.java
@@ -15,6 +15,7 @@ import org.jboss.logging.Logger;
 import com.github.eirslett.maven.plugins.frontend.lib.InstallationException;
 import com.github.eirslett.maven.plugins.frontend.lib.PackageManagerInstallFactory;
 
+import io.quarkiverse.quinoa.deployment.config.PackageManagerInstallAuthConfig;
 import io.quarkiverse.quinoa.deployment.config.PackageManagerInstallConfig;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -34,7 +35,8 @@ public final class PackageManagerInstall {
 
     }
 
-    public static Installation install(PackageManagerInstallConfig config, final Path projectDir, final Path uiDir) {
+    public static Installation install(PackageManagerInstallConfig config,
+            final Path projectDir, final Path uiDir) {
         Path installDir = resolveInstallDir(config, projectDir).normalize();
         if (config.nodeVersion().isEmpty()) {
             throw new ConfigurationException("node-version is required to install package manager",
@@ -49,7 +51,8 @@ public final class PackageManagerInstall {
         Vertx vertx = null;
         try {
             vertx = createVertxInstance();
-            PackageManagerInstallFactory factory = new PackageManagerInstallFactory(vertx, uiDir, installDir);
+            PackageManagerInstallFactory factory = new PackageManagerInstallFactory(vertx, uiDir, installDir,
+                    config.packageManagerInstallAuth().username().orElse(null), config.packageManagerInstallAuth().password().orElse(null));
             while (i < 5) {
                 try {
                     if (i > 0) {

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/PackageManagerInstall.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/PackageManagerInstall.java
@@ -15,7 +15,6 @@ import org.jboss.logging.Logger;
 import com.github.eirslett.maven.plugins.frontend.lib.InstallationException;
 import com.github.eirslett.maven.plugins.frontend.lib.PackageManagerInstallFactory;
 
-import io.quarkiverse.quinoa.deployment.config.PackageManagerInstallAuthConfig;
 import io.quarkiverse.quinoa.deployment.config.PackageManagerInstallConfig;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -52,7 +51,8 @@ public final class PackageManagerInstall {
         try {
             vertx = createVertxInstance();
             PackageManagerInstallFactory factory = new PackageManagerInstallFactory(vertx, uiDir, installDir,
-                    config.packageManagerInstallAuth().username().orElse(null), config.packageManagerInstallAuth().password().orElse(null));
+                    config.packageManagerInstallAuth().username().orElse(null),
+                    config.packageManagerInstallAuth().password().orElse(null));
             while (i < 5) {
                 try {
                     if (i > 0) {

--- a/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
@@ -265,6 +265,40 @@ endif::add-copy-button-to-env-var[]
 |`https://registry.npmjs.org/pnpm/-/`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.package-manager-install.basic-auth.username]]`link:#quarkus-quinoa_quarkus.quinoa.package-manager-install.basic-auth.username[quarkus.quinoa.package-manager-install.basic-auth.username]`
+
+
+[.description]
+--
+The basic authentication username to use for node download.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_PACKAGE_MANAGER_INSTALL_BASIC_AUTH_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_QUINOA_PACKAGE_MANAGER_INSTALL_BASIC_AUTH_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.package-manager-install.basic-auth.password]]`link:#quarkus-quinoa_quarkus.quinoa.package-manager-install.basic-auth.password[quarkus.quinoa.package-manager-install.basic-auth.password]`
+
+
+[.description]
+--
+The basic authentication password to use for node download.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_PACKAGE_MANAGER_INSTALL_BASIC_AUTH_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_QUINOA_PACKAGE_MANAGER_INSTALL_BASIC_AUTH_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus.quinoa.package-manager-command.install]]`link:#quarkus-quinoa_quarkus.quinoa.package-manager-command.install[quarkus.quinoa.package-manager-command.install]`
 
 


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Describe your changes

Implementation of basic authentication using new config properties.
quarkus.quinoa.package-manager-install.basic-auth.username
quarkus.quinoa.package-manager-install.basic-auth.password

This solution can currently only authenticate with the same credentials for all download URLs.

<!--  If your PR fixes an open issue then use Closes #31 -->
## Fixes Issue
Closes #614 
 
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--

[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done -->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
