### PR TITLE
Update web-frameworks.adoc

### DIFF
--- a/docs/modules/ROOT/pages/web-frameworks.adoc
+++ b/docs/modules/ROOT/pages/web-frameworks.adoc
@@ -255,7 +255,12 @@ Configure `svelte.config.js` file with the following changes:
 [source,javascript]
 ----
 import adapter from '@sveltejs/adapter-static';
+
+// In projects using Sveltekit v1
 import { vitePreprocess } from '@sveltejs/kit/vite';
+
+// In projects using SvelteKit v2
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
In Sveltekit v2 vite-plugin-svelte is added as a co-dependency and preprocessor is removed from Sveltekit v2, see:

https://kit.svelte.dev/docs/migrating-to-sveltekit-2#vitepreprocess-is-no-longer-exported-from-sveltejs-kit-vite

 <!--  Describe your changes below that what did you made change -->
## Describe your changes

Added a second import as well as a note in the docs regarding the use of quinoa with svelte.

<!--  If your PR fixes an open issue then use Closes #31 -->
## Fixes Issue

- Non-working set up of svelte web project
 
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--

[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done -->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
