### PR TITLE
SvelteKit: Document relative paths configuration

### DIFF
--- a/docs/modules/ROOT/pages/web-frameworks.adoc
+++ b/docs/modules/ROOT/pages/web-frameworks.adoc
@@ -268,7 +268,11 @@ const config = {
     kit: {
         adapter: adapter({
             fallback: 'index.html'
-        })
+        }),
+        // Mark path non-relative, otherwise SvelteKit assumes it works in a sub-directory
+        paths: {
+            relative: false
+        }
     }
 };
 


### PR DESCRIPTION
I ran into a weird behavior while developing a SvelteKit frontend with Quinoa 

Whenever a full reload happend an a nested route, it would give me a 404 error. But if I followed a link to that same route it worked just fine. 

Then I tried it without Quinoa proxying the request, and there the full reload also worked perfectly fine. 

It turns out that SvelteKit will assume that its base directory is whatever the current path's parent directory is if the request is proxied to it the way that Quiona does it. 

By configuring it to not assume that it should be using relative paths by default, the problem was resolved.

 <!--  Describe your changes below that what did you made change -->
## Describe your changes
Document how to configure SvelteKit to use absolute paths in its routing.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
