### PR TITLE
Changed port of dev url in documentation

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -93,6 +93,6 @@ $ quarkus build
 $ java -jar target/quarkus-app/quarkus-run.jar
 ----
 
-*It's done!* The web application is now built alongside Quarkus, dev-mode is available, and the generated files will be automatically copied to the right place and be served by Quinoa if you hit http://localhost:8080
+*It's done!* The web application is now built alongside Quarkus, dev-mode is available, and the generated files will be automatically copied to the right place and be served by Quinoa if you hit http://localhost:3000
 
 WARNING: With Quinoa, you don't need to manually copy the files to `META-INF/resources`. Quinoa has its own system and will provide another Vert.x route for it. *If you have conflicting files with `META-INF/resources`, Quinoa will have priority over them.*


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Documentation states after starting quarkus in dev-mode, frontend content will be served to localhost:8080 which is wrong since the config above shows the dev server on port 3000. This might be misleading.
 
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--

[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done -->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [X] My change requires changes to the documentation.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
