### PR TITLE
Fix ecosystem-ci

### DIFF
--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 %lit-root-path.quarkus.quinoa.enable-spa-routing=true
 %lit-root-path.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/foo/bar/
 
+quarkus.quinoa.ui-dir=src/main/ui-react
 %react.quarkus.quinoa.ui-dir=src/main/ui-react
 %vue.quarkus.quinoa.ui-dir=src/main/ui-vue
 %angular.quarkus.quinoa.ui-dir=src/main/ui-angular
@@ -22,4 +23,5 @@
 
 %yarn.quarkus.quinoa.package-manager=yarn
 %just-build.quarkus.quinoa.just-build=true
+
 


### PR DESCRIPTION
The QuarkusIntegrationTest uses React, this makes sure it is the default ui-dir for the native test.