### PR TITLE
Fix #682: Allow to define if dev-server is HTTPS / TLS

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
@@ -122,7 +122,8 @@ public class ForwardedDevProcessor {
         if (!devServerConfig.managed()) {
             // No need to start the dev-service it is not managed by Quinoa
             // We just check that it is up
-            final String resolvedHostIPAddress = PackageManagerRunner.isDevServerUp(configuredTls, configuredTlsAllowInsecure, configuredDevServerHost, port, checkPath);
+            final String resolvedHostIPAddress = PackageManagerRunner.isDevServerUp(configuredTls, configuredTlsAllowInsecure,
+                    configuredDevServerHost, port, checkPath);
             if (resolvedHostIPAddress != null) {
                 return new ForwardedDevServerBuildItem(resolvedHostIPAddress, port);
             } else {
@@ -139,7 +140,8 @@ public class ForwardedDevProcessor {
         final AtomicReference<Process> dev = new AtomicReference<>();
         PackageManagerRunner.DevServer devServer = null;
         try {
-            devServer = packageManagerRunner.dev(consoleInstalled, loggingSetup, configuredTls, configuredTlsAllowInsecure, configuredDevServerHost,
+            devServer = packageManagerRunner.dev(consoleInstalled, loggingSetup, configuredTls, configuredTlsAllowInsecure,
+                    configuredDevServerHost,
                     port,
                     checkPath,
                     checkTimeout);

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
@@ -79,6 +79,8 @@ public class ForwardedDevProcessor {
         final DevServerConfig devServerConfig = resolvedConfig.devServer();
         liveReload.setContextObject(QuinoaConfig.class, resolvedConfig);
         final String configuredDevServerHost = devServerConfig.host();
+        final boolean configuredTls = devServerConfig.tls();
+        final boolean configuredTlsAllowInsecure = devServerConfig.tlsAllowInsecure();
         final PackageManagerRunner packageManagerRunner = installedPackageManager.getPackageManager();
         final String checkPath = resolvedConfig.devServer().checkPath().orElse(null);
         if (devService != null) {
@@ -92,7 +94,9 @@ public class ForwardedDevProcessor {
                 }
                 LOG.debug("Quinoa config did not change; no need to restart.");
                 devServices.produce(devService.toBuildItem());
-                final String resolvedDevServerHost = PackageManagerRunner.isDevServerUp(devServerConfig.host(),
+                final String resolvedDevServerHost = PackageManagerRunner.isDevServerUp(devServerConfig.tls(),
+                        devServerConfig.tlsAllowInsecure(),
+                        devServerConfig.host(),
                         devServerConfig.port().get(),
                         checkPath);
                 return new ForwardedDevServerBuildItem(resolvedDevServerHost, devServerConfig.port().get());
@@ -118,7 +122,7 @@ public class ForwardedDevProcessor {
         if (!devServerConfig.managed()) {
             // No need to start the dev-service it is not managed by Quinoa
             // We just check that it is up
-            final String resolvedHostIPAddress = PackageManagerRunner.isDevServerUp(configuredDevServerHost, port, checkPath);
+            final String resolvedHostIPAddress = PackageManagerRunner.isDevServerUp(configuredTls, configuredTlsAllowInsecure, configuredDevServerHost, port, checkPath);
             if (resolvedHostIPAddress != null) {
                 return new ForwardedDevServerBuildItem(resolvedHostIPAddress, port);
             } else {
@@ -135,7 +139,7 @@ public class ForwardedDevProcessor {
         final AtomicReference<Process> dev = new AtomicReference<>();
         PackageManagerRunner.DevServer devServer = null;
         try {
-            devServer = packageManagerRunner.dev(consoleInstalled, loggingSetup, configuredDevServerHost,
+            devServer = packageManagerRunner.dev(consoleInstalled, loggingSetup, configuredTls, configuredTlsAllowInsecure, configuredDevServerHost,
                     port,
                     checkPath,
                     checkTimeout);

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/SslUtil.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/SslUtil.java
@@ -1,0 +1,55 @@
+package io.quarkiverse.quinoa.deployment;
+
+import javax.net.ssl.*;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+public class SslUtil {
+    private final static X509ExtendedTrustManager NON_VALIDATING_TRUST_MANAGER = new X509ExtendedTrustManager() {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    };
+
+    public static SSLContext createNonValidatingSslContext()  {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new TrustManager[]{NON_VALIDATING_TRUST_MANAGER}, new SecureRandom());
+            return sslContext;
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/SslUtil.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/SslUtil.java
@@ -43,10 +43,10 @@ public class SslUtil {
         }
     };
 
-    public static SSLContext createNonValidatingSslContext()  {
+    public static SSLContext createNonValidatingSslContext() {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, new TrustManager[]{NON_VALIDATING_TRUST_MANAGER}, new SecureRandom());
+            sslContext.init(null, new TrustManager[] { NON_VALIDATING_TRUST_MANAGER }, new SecureRandom());
             return sslContext;
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             throw new RuntimeException(e);

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/DevServerConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/DevServerConfig.java
@@ -112,10 +112,10 @@ public interface DevServerConfig {
         if (!Objects.equals(d1.host(), d2.host())) {
             return false;
         }
-        if(!Objects.equals(d1.tls(), d2.tls())) {
+        if (!Objects.equals(d1.tls(), d2.tls())) {
             return false;
         }
-        if(!Objects.equals(d1.tlsAllowInsecure(), d2.tlsAllowInsecure())) {
+        if (!Objects.equals(d1.tlsAllowInsecure(), d2.tlsAllowInsecure())) {
             return false;
         }
         if (!Objects.equals(d1.checkPath(), d2.checkPath())) {

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/DevServerConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/DevServerConfig.java
@@ -41,6 +41,18 @@ public interface DevServerConfig {
     String host();
 
     /**
+     * Protocol of the server to forward requests to.
+     */
+    @WithDefault("false")
+    boolean tls();
+
+    /**
+     * Protocol of the server to forward requests to.
+     */
+    @WithDefault("false")
+    boolean tlsAllowInsecure();
+
+    /**
      * After start, Quinoa wait for the external dev server.
      * by sending GET requests to this path waiting for a 200 status.
      * If forced empty, Quinoa will not check if the dev server is up.
@@ -98,6 +110,12 @@ public interface DevServerConfig {
             return false;
         }
         if (!Objects.equals(d1.host(), d2.host())) {
+            return false;
+        }
+        if(!Objects.equals(d1.tls(), d2.tls())) {
+            return false;
+        }
+        if(!Objects.equals(d1.tlsAllowInsecure(), d2.tlsAllowInsecure())) {
             return false;
         }
         if (!Objects.equals(d1.checkPath(), d2.checkPath())) {

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/delegate/DevServerConfigDelegate.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/delegate/DevServerConfigDelegate.java
@@ -32,6 +32,16 @@ public class DevServerConfigDelegate implements DevServerConfig {
     }
 
     @Override
+    public boolean tls() {
+        return delegate.tls();
+    }
+
+    @Override
+    public boolean tlsAllowInsecure() {
+        return delegate.tlsAllowInsecure();
+    }
+
+    @Override
     public Optional<String> checkPath() {
         return delegate.checkPath();
     }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/PackageManagerRunner.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/PackageManagerRunner.java
@@ -139,7 +139,8 @@ public class PackageManagerRunner {
     }
 
     public DevServer dev(Optional<ConsoleInstalledBuildItem> consoleInstalled, LoggingSetupBuildItem loggingSetup,
-            boolean tls, boolean tlsAllowInsecure, String devServerHost, int devServerPort, String checkPath, int checkTimeout) {
+            boolean tls, boolean tlsAllowInsecure, String devServerHost, int devServerPort, String checkPath,
+            int checkTimeout) {
         final PackageManager.Command dev = packageManager.dev();
         LOG.infof("Running Quinoa package manager live coding as a dev service: %s", dev.commandWithArguments);
         StartupLogCompressor logCompressor = new StartupLogCompressor(
@@ -287,9 +288,9 @@ public class PackageManagerRunner {
                     final String ipAddress = address instanceof Inet6Address ? "[" + hostAddress + "]" : hostAddress;
                     URL url = new URL(String.format("%s://%s:%d%s", tls ? "https" : "http", ipAddress, port, normalizedPath));
                     HttpURLConnection connection;
-                    if(tls){
+                    if (tls) {
                         HttpsURLConnection httpsConnection = (HttpsURLConnection) url.openConnection();
-                        if(tlsAllowInsecure) {
+                        if (tlsAllowInsecure) {
                             httpsConnection.setSSLSocketFactory(SslUtil.createNonValidatingSslContext().getSocketFactory());
                             httpsConnection.setHostnameVerifier(new HostnameVerifier() {
                                 @Override
@@ -299,7 +300,7 @@ public class PackageManagerRunner {
                             });
                         }
                         connection = httpsConnection;
-                    }else{
+                    } else {
                         connection = (HttpURLConnection) url.openConnection();
                     }
 

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/PackageManagerRunner.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/packagemanager/PackageManagerRunner.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
+import io.quarkiverse.quinoa.deployment.SslUtil;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.quinoa.deployment.config.PackageManagerCommandConfig;
@@ -32,6 +33,10 @@ import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.deployment.util.ProcessUtil;
 import io.quarkus.dev.console.QuarkusConsole;
 import io.quarkus.runtime.LaunchMode;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSession;
 
 public class PackageManagerRunner {
     private static final Logger LOG = Logger.getLogger(PackageManagerRunner.class);
@@ -134,7 +139,7 @@ public class PackageManagerRunner {
     }
 
     public DevServer dev(Optional<ConsoleInstalledBuildItem> consoleInstalled, LoggingSetupBuildItem loggingSetup,
-            String devServerHost, int devServerPort, String checkPath, int checkTimeout) {
+            boolean tls, boolean tlsAllowInsecure, String devServerHost, int devServerPort, String checkPath, int checkTimeout) {
         final PackageManager.Command dev = packageManager.dev();
         LOG.infof("Running Quinoa package manager live coding as a dev service: %s", dev.commandWithArguments);
         StartupLogCompressor logCompressor = new StartupLogCompressor(
@@ -155,7 +160,7 @@ public class PackageManagerRunner {
         String ipAddress = null;
         try {
             int i = 0;
-            while ((ipAddress = isDevServerUp(devServerHost, devServerPort, checkPath)) == null) {
+            while ((ipAddress = isDevServerUp(tls, tlsAllowInsecure, devServerHost, devServerPort, checkPath)) == null) {
                 if (++i >= checkTimeout / 500) {
                     stopDev(p);
                     throw new RuntimeException(
@@ -269,7 +274,7 @@ public class PackageManagerRunner {
         }
     }
 
-    public static String isDevServerUp(String host, int port, String path) {
+    public static String isDevServerUp(boolean tls, boolean tlsAllowInsecure, String host, int port, String path) {
         if (path == null) {
             return host;
         }
@@ -280,8 +285,24 @@ public class PackageManagerRunner {
                 try {
                     final String hostAddress = address.getHostAddress();
                     final String ipAddress = address instanceof Inet6Address ? "[" + hostAddress + "]" : hostAddress;
-                    URL url = new URL(String.format("http://%s:%d%s", ipAddress, port, normalizedPath));
-                    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                    URL url = new URL(String.format("%s://%s:%d%s", tls ? "https" : "http", ipAddress, port, normalizedPath));
+                    HttpURLConnection connection;
+                    if(tls){
+                        HttpsURLConnection httpsConnection = (HttpsURLConnection) url.openConnection();
+                        if(tlsAllowInsecure) {
+                            httpsConnection.setSSLSocketFactory(SslUtil.createNonValidatingSslContext().getSocketFactory());
+                            httpsConnection.setHostnameVerifier(new HostnameVerifier() {
+                                @Override
+                                public boolean verify(String hostname, SSLSession session) {
+                                    return true;
+                                }
+                            });
+                        }
+                        connection = httpsConnection;
+                    }else{
+                        connection = (HttpURLConnection) url.openConnection();
+                    }
+
                     connection.setRequestMethod("GET");
                     connection.setConnectTimeout(2000);
                     connection.setReadTimeout(2000);


### PR DESCRIPTION
Fix #682: Allow to define if dev-server is HTTPS / TLS

This PR add support for HTTPS/TLS for dev-server.

It's my first PR on quarkus and quinoa so if I missed some standard/convention and need rework, tell me (or do the change).

Thanks.