### PR TITLE
Add root path for Quinoa Web UI

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -230,7 +230,7 @@ public class QuinoaProcessor {
             String uiRootPath = QuinoaConfig.getNormalizedUiRootPath(configuredQuinoa.resolvedConfig());
             for (BuiltResourcesBuildItem.BuiltResource resource : uiResources.get().resources()) {
                 // note how uiRootPath always starts and ends in a slash
-                // and resource.name() always starts in a slash
+                // and resource.name() always starts in a slash, therfore resource.name().substring(1) never starts in a slash
                 generatedStaticResourceProducer
                         .produce(new GeneratedStaticResourceBuildItem(uiRootPath + resource.name().substring(1),
                                 resource.content()));
@@ -252,7 +252,9 @@ public class QuinoaProcessor {
         }
         if (uiResources.isPresent() && !uiResources.get().resources().isEmpty()) {
             String uiRootPath = QuinoaConfig.getNormalizedUiRootPath(configuredQuinoa.resolvedConfig());
-            recorder.logUiRootPath(httpRootPath.relativePath(uiRootPath));
+            // the resolvedUiRootPath is only used for logging
+            String resolvedUiRootPath = httpRootPath.relativePath(uiRootPath);
+            recorder.logUiRootPath(resolvedUiRootPath.endsWith("/") ? resolvedUiRootPath : resolvedUiRootPath + "/");
             if (configuredQuinoa.resolvedConfig().enableSPARouting()) {
                 routes.produce(RouteBuildItem.builder().orderedRoute(uiRootPath + "*", QUINOA_SPA_ROUTE_ORDER)
                         .handler(recorder

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
@@ -198,7 +198,8 @@ public interface QuinoaConfig {
                 .map(s -> normalizePath(s, true))
                 // only add this path if it is relative to the ui-root-path
                 .flatMap(s -> relativizePath(uiRootPath, s))
-                .filter(s -> !Objects.equals(s, "/"));
+                .filter(s -> !Objects.equals(s, "/"))
+                .map(s -> s.endsWith("/") ? s.substring(0, s.length() - 1) : s);
     }
 
     private static Optional<String> convertNonApplicationRootPath(String uiRootPath,
@@ -209,7 +210,8 @@ public interface QuinoaConfig {
                 nonApplicationRootPath.getNonApplicationRootPath())
                 // and also only add this path if it is relative to the ui-root-path
                 .flatMap(s -> relativizePath(uiRootPath, s))
-                .filter(s -> !Objects.equals(s, "/"));
+                .filter(s -> !Objects.equals(s, "/"))
+                .map(s -> s.endsWith("/") ? s.substring(0, s.length() - 1) : s);
     }
 
     static boolean isDevServerMode(QuinoaConfig config) {

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/delegate/QuinoaConfigDelegate.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/delegate/QuinoaConfigDelegate.java
@@ -27,6 +27,11 @@ public class QuinoaConfigDelegate implements QuinoaConfig {
     }
 
     @Override
+    public String uiRootPath() {
+        return delegate.uiRootPath();
+    }
+
+    @Override
     public String uiDir() {
         return delegate.uiDir();
     }

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
@@ -30,7 +30,7 @@ public class QuinoaPathPrefixesRESTConfigRelativeRootPathTest {
                             // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
                             .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /root/path")));
+                            .equals("Quinoa is available at: /root/path/")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
@@ -28,7 +28,7 @@ public class QuinoaPathPrefixesRESTConfigRelativeRootPathTest {
                             // note how /bar/non is part of the ignored paths
                             // this is because bar/non is relative to the root path when it does not start with a slash
                             // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
-                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
+                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic, /foo/reactive, /bar/non"))
                     .anyMatch(s -> s.getMessage()
                             .equals("Quinoa is available at: /root/path/")));
 

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
@@ -11,22 +11,26 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class QuinoaPathPrefixesRESTConfigTest {
+public class QuinoaPathPrefixesRESTConfigRelativeRootPathTest {
 
-    private static final String NAME = "resteasy-reactive-path-config";
+    private static final String NAME = "resteasy-reactive-path-config-relative-root-path";
 
     @RegisterExtension
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create(NAME)
             .toQuarkusUnitTest()
-            .overrideConfigKey("quarkus.rest.path", "/foo/reactive")
-            .overrideConfigKey("quarkus.resteasy.path", "/foo/classic")
-            .overrideConfigKey("quarkus.http.non-application-root-path", "/bar/non")
+            .overrideConfigKey("quarkus.http.root-path", "root/path")
+            .overrideConfigKey("quarkus.rest.path", "foo/reactive")
+            .overrideConfigKey("quarkus.resteasy.path", "foo/classic")
+            .overrideConfigKey("quarkus.http.non-application-root-path", "bar/non")
             .overrideConfigKey("quarkus.quinoa.enable-spa-routing", "true")
             .assertLogRecords(l -> assertThat(l)
                     .anyMatch(s -> s.getMessage()
+                            // note how /bar/non is part of the ignored paths
+                            // this is because bar/non is relative to the root path when it does not start with a slash
+                            // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
                             .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /")));
+                            .equals("Quinoa is available at: /root/path")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
@@ -11,22 +11,26 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class QuinoaPathPrefixesRESTConfigTest {
+public class QuinoaPathPrefixesRESTConfigRootPathTest {
 
-    private static final String NAME = "resteasy-reactive-path-config";
+    private static final String NAME = "resteasy-reactive-path-config-root-path";
 
     @RegisterExtension
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create(NAME)
             .toQuarkusUnitTest()
+            .overrideConfigKey("quarkus.http.root-path", "/root/path")
             .overrideConfigKey("quarkus.rest.path", "/foo/reactive")
             .overrideConfigKey("quarkus.resteasy.path", "/foo/classic")
             .overrideConfigKey("quarkus.http.non-application-root-path", "/bar/non")
             .overrideConfigKey("quarkus.quinoa.enable-spa-routing", "true")
             .assertLogRecords(l -> assertThat(l)
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
+                            // note how /bar/non is not part of the ignored paths
+                            // this is because /bar/non is not relative to /root/path
+                            // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
+                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic/, /foo/reactive/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /")));
+                            .equals("Quinoa is available at: /root/path")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
@@ -28,7 +28,7 @@ public class QuinoaPathPrefixesRESTConfigRootPathTest {
                             // note how /bar/non is not part of the ignored paths
                             // this is because /bar/non is not relative to /root/path
                             // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
-                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic/, /foo/reactive/"))
+                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic, /foo/reactive"))
                     .anyMatch(s -> s.getMessage()
                             .equals("Quinoa is available at: /root/path/")));
 

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
@@ -30,7 +30,7 @@ public class QuinoaPathPrefixesRESTConfigRootPathTest {
                             // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
                             .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic/, /foo/reactive/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /root/path")));
+                            .equals("Quinoa is available at: /root/path/")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigTest.java
@@ -24,7 +24,7 @@ public class QuinoaPathPrefixesRESTConfigTest {
             .overrideConfigKey("quarkus.quinoa.enable-spa-routing", "true")
             .assertLogRecords(l -> assertThat(l)
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
+                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic, /foo/reactive, /bar/non"))
                     .anyMatch(s -> s.getMessage()
                             .equals("Quinoa is available at: /")));
 

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
@@ -29,7 +29,7 @@ public class QuinoaPathPrefixesRESTConfigUiRootPathTest {
                             // ignored paths are always relative to the ui root path
                             .equals("Quinoa SPA routing handler is ignoring paths starting with: /classic/, /reactive/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /root/path/foo")));
+                            .equals("Quinoa is available at: /root/path/foo/")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
@@ -11,22 +11,25 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class QuinoaPathPrefixesRESTConfigTest {
+public class QuinoaPathPrefixesRESTConfigUiRootPathTest {
 
-    private static final String NAME = "resteasy-reactive-path-config";
+    private static final String NAME = "resteasy-reactive-path-config-ui-root-path";
 
     @RegisterExtension
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create(NAME)
             .toQuarkusUnitTest()
+            .overrideConfigKey("quarkus.http.root-path", "/root/path")
+            .overrideConfigKey("quarkus.quinoa.ui-root-path", "/foo")
             .overrideConfigKey("quarkus.rest.path", "/foo/reactive")
             .overrideConfigKey("quarkus.resteasy.path", "/foo/classic")
             .overrideConfigKey("quarkus.http.non-application-root-path", "/bar/non")
             .overrideConfigKey("quarkus.quinoa.enable-spa-routing", "true")
             .assertLogRecords(l -> assertThat(l)
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
+                            // ignored paths are always relative to the ui root path
+                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /classic/, /reactive/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /")));
+                            .equals("Quinoa is available at: /root/path/foo")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
@@ -27,7 +27,7 @@ public class QuinoaPathPrefixesRESTConfigUiRootPathTest {
             .assertLogRecords(l -> assertThat(l)
                     .anyMatch(s -> s.getMessage()
                             // ignored paths are always relative to the ui root path
-                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /classic/, /reactive/"))
+                            .equals("Quinoa SPA routing handler is ignoring paths starting with: /classic, /reactive"))
                     .anyMatch(s -> s.getMessage()
                             .equals("Quinoa is available at: /root/path/foo/")));
 

--- a/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
@@ -44,6 +44,23 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-ui-root-path]]`link:#quarkus-quinoa_quarkus-quinoa-ui-root-path[quarkus.quinoa.ui-root-path]`
+
+
+[.description]
+--
+Root path for hosting the Web UI. This path is normalized and always resolved relative to 'quarkus.http.root-path'.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_UI_ROOT_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_QUINOA_UI_ROOT_PATH+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`/`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-ui-dir]]`link:#quarkus-quinoa_quarkus-quinoa-ui-dir[quarkus.quinoa.ui-dir]`
 
 
@@ -474,7 +491,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-ignored-p
 
 [.description]
 --
-List of path prefixes to be ignored by Quinoa (SPA Handler and Dev-Proxy).
+List of path prefixes to be ignored by Quinoa (SPA Handler and Dev-Proxy). The paths are normalized and always resolved relative to 'quarkus.quinoa.ui-root-path'.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_IGNORED_PATH_PREFIXES+++[]
@@ -483,7 +500,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_QUINOA_IGNORED_PATH_PREFIXES+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
-|`ignore values configured by 'quarkus.resteasy-reactive.path', 'quarkus.resteasy.path' and 'quarkus.http.non-application-root-path'`
+|`ignore values configured by 'quarkus.resteasy-reactive.path', 'quarkus.rest.path', 'quarkus.resteasy.path' and 'quarkus.http.non-application-root-path'`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-dev-server]]`link:#quarkus-quinoa_quarkus-quinoa-dev-server[quarkus.quinoa.dev-server]`
@@ -552,6 +569,40 @@ Environment variable: `+++QUARKUS_QUINOA_DEV_SERVER_HOST+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |`localhost`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-dev-server-tls]]`link:#quarkus-quinoa_quarkus-quinoa-dev-server-tls[quarkus.quinoa.dev-server.tls]`
+
+
+[.description]
+--
+Protocol of the server to forward requests to.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_DEV_SERVER_TLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_QUINOA_DEV_SERVER_TLS+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-dev-server-tls-allow-insecure]]`link:#quarkus-quinoa_quarkus-quinoa-dev-server-tls-allow-insecure[quarkus.quinoa.dev-server.tls-allow-insecure]`
+
+
+[.description]
+--
+Protocol of the server to forward requests to.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_DEV_SERVER_TLS_ALLOW_INSECURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_QUINOA_DEV_SERVER_TLS_ALLOW_INSECURE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-dev-server-check-path]]`link:#quarkus-quinoa_quarkus-quinoa-dev-server-check-path[quarkus.quinoa.dev-server.check-path]`
@@ -636,7 +687,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_QUINOA_DEV_SERVER_INDEX_PAGE+++`
 endif::add-copy-button-to-env-var[]
 --|string 
-|`auto-detected falling back to the quinoa.index-page`
+|`auto-detected falling back to index.html`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-dev-server-direct-forwarding]]`link:#quarkus-quinoa_quarkus-quinoa-dev-server-direct-forwarding[quarkus.quinoa.dev-server.direct-forwarding]`

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,6 +1,12 @@
-%lit-root-path.quarkus.http.root-path=/foo/bar
-%lit-root-path.quarkus.quinoa.enable-spa-routing=true
-%lit-root-path.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/foo/bar/
+%lit-root-path,lit-ui-root-path.quarkus.http.root-path=/foo/bar
+%lit-root-path,lit-ui-root-path.quarkus.quinoa.enable-spa-routing=true
+%lit-root-path,lit-ui-root-path.quarkus.quinoa.package-manager-command.build-env.API_PATH=/foo/bar/api/
+
+%lit-root-path.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/foo/bar
+
+%lit-ui-root-path.quarkus.quinoa.ui-root-path=/ui
+%lit-ui-root-path.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/foo/bar/ui
+%lit-ui-root-path.quarkus.quinoa.ignored-path-prefixes=/ignored
 
 quarkus.quinoa.ui-dir=src/main/ui-react
 %react.quarkus.quinoa.ui-dir=src/main/ui-react
@@ -13,13 +19,14 @@ quarkus.quinoa.ui-dir=src/main/ui-react
 %angular.quarkus.quinoa.package-manager-install.install-dir=target/
 %angular.quarkus.quinoa.package-manager-install.node-version=20.9.0
 %angular.quarkus.quinoa.package-manager-install.yarn-version=1.22.19
-%lit,lit-root-path.quarkus.quinoa.ui-dir=src/main/ui-lit
-%lit,lit-root-path.quarkus.quinoa.build-dir=dist
-%lit,lit-root-path.quarkus.http.static-resources.index-page=app.html
-%lit,lit-root-path.quarkus.quinoa.package-manager-command.build=run build-per-env
-%lit-root-path.quarkus.quinoa.package-manager-command.build-env.FOO=bar
+%lit,lit-root-path,lit-ui-root-path.quarkus.quinoa.ui-dir=src/main/ui-lit
+%lit,lit-root-path,lit-ui-root-path.quarkus.quinoa.build-dir=dist
+%lit,lit-root-path,lit-ui-root-path.quarkus.http.static-resources.index-page=app.html
+%lit,lit-root-path,lit-ui-root-path.quarkus.quinoa.package-manager-command.build=run build-per-env
+%lit-root-path,lit-ui-root-path.quarkus.quinoa.package-manager-command.build-env.FOO=bar
 %lit.quarkus.quinoa.package-manager-command.build-env.FOO=bar
 %lit.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/
+%lit.quarkus.quinoa.package-manager-command.build-env.API_PATH=/api/
 
 %yarn.quarkus.quinoa.package-manager=yarn
 %just-build.quarkus.quinoa.just-build=true

--- a/integration-tests/src/main/ui-lit/src/simple-greeting.js
+++ b/integration-tests/src/main/ui-lit/src/simple-greeting.js
@@ -1,6 +1,6 @@
 import {html, css, LitElement} from 'lit';
 
-const ROOT_PATH = process.env.ROOT_PATH;
+const API_PATH = process.env.API_PATH;
 
 export class SimpleGreeting extends LitElement {
     static styles = css`p { color: blue }`;
@@ -17,7 +17,7 @@ export class SimpleGreeting extends LitElement {
     render() {
         const xmlHttp = new XMLHttpRequest();
 
-        xmlHttp.open( "GET", `${ROOT_PATH}api/quinoa`, false );
+        xmlHttp.open( "GET", `${API_PATH}quinoa`, false );
         xmlHttp.send( null );
         const response = xmlHttp.responseText;
         return html`<p class="greeting">${response} and ${this.name} and ${process.env.FOO}</p>`;

--- a/integration-tests/src/main/ui-lit/webpack.config.js
+++ b/integration-tests/src/main/ui-lit/webpack.config.js
@@ -12,6 +12,6 @@ module.exports = {
                 { from: 'public' }
             ]
         }),
-        new EnvironmentPlugin(['FOO', 'ROOT_PATH'])
+        new EnvironmentPlugin(['FOO', 'ROOT_PATH', 'API_PATH'])
     ]
 };

--- a/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaUiRootPathTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaUiRootPathTest.java
@@ -1,0 +1,83 @@
+package io.quarkiverse.quinoa.it;
+
+import static io.restassured.RestAssured.given;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.ElementHandle;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Response;
+
+import io.quarkiverse.playwright.InjectPlaywright;
+import io.quarkiverse.playwright.WithPlaywright;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(TestProfiles.UiRootPathTests.class)
+@WithPlaywright
+public class QuinoaUiRootPathTest {
+
+    @InjectPlaywright
+    BrowserContext context;
+
+    @TestHTTPResource("/")
+    URL url404Root;
+
+    @TestHTTPResource("/ui/ignored")
+    URL url404Ignored;
+
+    // note how the path "/ui" does not work in a production build
+    // note that "/ui" works in dev-mode as long as the nodejs server also hosts "/ui"
+    @TestHTTPResource("/ui/")
+    URL url;
+
+    @TestHTTPResource("/ui/some-route")
+    URL urlRoute;
+
+    @Test
+    public void test404Endpoints() {
+        given()
+                .when().get(url404Root)
+                .then()
+                .statusCode(404);
+        given()
+                .when().get(url404Ignored)
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testUIIndex() {
+        final Page page = context.newPage();
+        Response response = page.navigate(url.toString());
+        Assertions.assertEquals("OK", response.statusText());
+
+        page.waitForLoadState();
+
+        String title = page.title();
+        Assertions.assertEquals("Quinoa Lit App", title);
+
+        // Make sure the component loaded and hits the backend
+        final ElementHandle quinoaEl = page.waitForSelector(".greeting");
+        String greeting = quinoaEl.innerText();
+        Assertions.assertEquals("Hello Quinoa and World and bar", greeting);
+    }
+
+    @Test
+    public void testRoute() {
+        final Page page = context.newPage();
+        Response response = page.navigate(urlRoute.toString());
+        Assertions.assertEquals("OK", response.statusText());
+
+        page.waitForLoadState();
+
+        String title = page.title();
+        Assertions.assertEquals("Quinoa Lit App", title);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaUiRootPathTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaUiRootPathTest.java
@@ -32,6 +32,13 @@ public class QuinoaUiRootPathTest {
     @TestHTTPResource("/ui/ignored")
     URL url404Ignored;
 
+    @TestHTTPResource("/ui/ignored/sub-path")
+    URL url404IgnoredSubPath;
+
+    // this path starts with /ignored, but is not a sub path of /ignored
+    @TestHTTPResource("/ui/ignored-not-ignored")
+    URL urlNotIgnored;
+
     // note how the path "/ui" does not work in a production build
     // note that "/ui" works in dev-mode as long as the nodejs server also hosts "/ui"
     @TestHTTPResource("/ui/")
@@ -48,6 +55,10 @@ public class QuinoaUiRootPathTest {
                 .statusCode(404);
         given()
                 .when().get(url404Ignored)
+                .then()
+                .statusCode(404);
+        given()
+                .when().get(url404IgnoredSubPath)
                 .then()
                 .statusCode(404);
     }
@@ -73,6 +84,18 @@ public class QuinoaUiRootPathTest {
     public void testRoute() {
         final Page page = context.newPage();
         Response response = page.navigate(urlRoute.toString());
+        Assertions.assertEquals("OK", response.statusText());
+
+        page.waitForLoadState();
+
+        String title = page.title();
+        Assertions.assertEquals("Quinoa Lit App", title);
+    }
+
+    @Test
+    public void testNotIgnored() {
+        final Page page = context.newPage();
+        Response response = page.navigate(urlNotIgnored.toString());
         Assertions.assertEquals("OK", response.statusText());
 
         page.waitForLoadState();

--- a/integration-tests/src/test/java/io/quarkiverse/quinoa/it/TestProfiles.java
+++ b/integration-tests/src/test/java/io/quarkiverse/quinoa/it/TestProfiles.java
@@ -46,6 +46,13 @@ public class TestProfiles {
         }
     }
 
+    public static class UiRootPathTests extends QuinoaTestProfiles.Enable {
+        @Override
+        public String getConfigProfile() {
+            return "lit-ui-root-path";
+        }
+    }
+
     public static class VueTests extends QuinoaTestProfiles.Enable {
         @Override
         public String getConfigProfile() {

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
@@ -28,7 +28,7 @@ public class QuinoaRecorder {
     public Handler<RoutingContext> quinoaProxyDevHandler(final QuinoaDevProxyHandlerConfig handlerConfig, Supplier<Vertx> vertx,
             String host, int port, boolean websocket) {
         if (LOG.isDebugEnabled()) {
-            LOG.debugf("Quinoa dev proxy-handler is ignoring paths starting with: "
+            LOG.debug("Quinoa dev proxy-handler is ignoring paths starting with: "
                     + String.join(", ", handlerConfig.ignoredPathPrefixes));
         }
         return new QuinoaDevProxyHandler(handlerConfig, vertx.get(), host, port, websocket);
@@ -36,22 +36,36 @@ public class QuinoaRecorder {
 
     public Handler<RoutingContext> quinoaSPARoutingHandler(List<String> ignoredPathPrefixes) throws IOException {
         if (LOG.isDebugEnabled()) {
-            LOG.debugf("Quinoa SPA routing handler is ignoring paths starting with: " + String.join(", ", ignoredPathPrefixes));
+            LOG.debug("Quinoa SPA routing handler is ignoring paths starting with: " + String.join(", ", ignoredPathPrefixes));
         }
         return new QuinoaSPARoutingHandler(ignoredPathPrefixes);
     }
 
+    public void logUiRootPath(final String resolvedUiRootPath) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Quinoa is available at: " + resolvedUiRootPath);
+        }
+    }
+
     static String resolvePath(RoutingContext ctx) {
-        return (ctx.mountPoint() == null) ? ctx.normalizedPath()
+        // quarkus.http.root-path
+        String path = (ctx.mountPoint() == null) ? ctx.normalizedPath()
                 : ctx.normalizedPath().substring(
                         // let's be extra careful here in case Vert.x normalizes the mount points at
                         // some point
                         ctx.mountPoint().endsWith("/") ? ctx.mountPoint().length() - 1 : ctx.mountPoint().length());
+        // quarkus.quinoa.ui-root-path
+        String routePath = ctx.currentRoute().getPath();
+        String resolvedPath = (routePath == null) ? path
+                : path.substring(routePath.endsWith("/") ? routePath.length() - 1 : routePath.length());
+        // use "/" when the path is empty
+        // e.g. this happens when the request path is "/example" and the root path is "/example"
+        return resolvedPath.isEmpty() ? "/" : resolvedPath;
     }
 
     static boolean isIgnored(final String path, final List<String> ignoredPathPrefixes) {
         if (ignoredPathPrefixes.stream().anyMatch(path::startsWith)) {
-            LOG.debugf("Quinoa is ignoring path (quarkus.quinoa.ignored-path-prefixes): " + path);
+            LOG.debug("Quinoa is ignoring path (quarkus.quinoa.ignored-path-prefixes): " + path);
             return true;
         }
         return false;

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
@@ -4,6 +4,7 @@ import static io.quarkus.vertx.http.runtime.RouteConstants.ROUTE_ORDER_DEFAULT;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -63,8 +64,18 @@ public class QuinoaRecorder {
         return resolvedPath.isEmpty() ? "/" : resolvedPath;
     }
 
+    static boolean matchesPathSeparatedPrefix(String path, String pathSeparatedPrefix) {
+        if (path.startsWith(pathSeparatedPrefix)) {
+            String restPath = path.substring(pathSeparatedPrefix.length());
+            // the path matches the path separated prefix if the rest path is empty or starts with "/"
+            // note that the pathSeparatedPrefix never ends in "/" except if it equals "/" exactly
+            return restPath.isEmpty() || restPath.startsWith("/") || Objects.equals(pathSeparatedPrefix, "/");
+        }
+        return false;
+    }
+
     static boolean isIgnored(final String path, final List<String> ignoredPathPrefixes) {
-        if (ignoredPathPrefixes.stream().anyMatch(path::startsWith)) {
+        if (ignoredPathPrefixes.stream().anyMatch(prefix -> matchesPathSeparatedPrefix(path, prefix))) {
             LOG.debug("Quinoa is ignoring path (quarkus.quinoa.ignored-path-prefixes): " + path);
             return true;
         }

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaSPARoutingHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaSPARoutingHandler.java
@@ -31,8 +31,16 @@ class QuinoaSPARoutingHandler implements Handler<RoutingContext> {
         }
         String path = resolvePath(ctx);
         if (!Objects.equals(path, "/") && !isIgnored(path, ignoredPathPrefixes)) {
-            LOG.debugf("Quinoa is re-routing SPA request '%s' to '/'", ctx.normalizedPath());
-            ctx.reroute(ctx.mountPoint() != null ? ctx.mountPoint() : "/");
+            String mountPoint = ctx.mountPoint() != null ? ctx.mountPoint() : "/";
+            String routePath = ctx.currentRoute().getPath() != null ? ctx.currentRoute().getPath() : "/";
+            String target;
+            if (mountPoint.endsWith("/")) {
+                target = mountPoint.substring(0, mountPoint.length() - 1) + routePath;
+            } else {
+                target = mountPoint + routePath;
+            }
+            LOG.debugf("Quinoa is re-routing SPA request '%s' to '%s'", ctx.normalizedPath(), target);
+            ctx.reroute(target);
         } else {
             next(currentClassLoader, ctx);
         }


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Describe your changes
This change adds the following new property: `quarkus.quinoa.ui-root-path`
This is the path where the Web UI will be hosted and is always relative to `quarkus.http.root-path`.
The default value is `/`, which is a non-breaking change.

For example setting the property `quarkus.quinoa.ui-root-path=/ui` would serve the Web UI at the path `/ui`.

The paths in the property `quarkus.quinoa.ignored-path-prefixes` are relative to `quarkus.quinoa.ui-root-path` which is a non-braking change because the default of `quarkus.quinoa.ui-root-path` is `/`.
I added normalization to the ignored paths, so paths like `foo///bar` would now be added as `/foo/bar` and this should be good since ignored paths are checked against the normalized request path from vertx.
When the property is not set then the automatic values are adjusted.
For example when the following properties are set:
```properties
quarkus.quinoa.ui-root-path=/app
quarkus.rest.path=/app/api
quarkus.http.non-application-root-path=/q
```
Then `/api/` will be added to the ignored paths automatically.
Note how `/q/` is not added to the ignored paths, since it is not a sub-path of `/app` and the path `/app/api/` was adjusted to `/api/` since the ignored paths are relative to the ui-root-path.

**Bug-Fix:**
The changes also contain the following bug fix which was an issue even before these changes:
The `quarkus.http.non-application-root-path` is now added correctly to the ignored paths.
This is because `quarkus.http.non-application-root-path` is only relative to `quarkus.http.root-path` if the non-application path does not start with a slash (`/`), otherwise it will be an absolute path that is not relative to `quarkus.http.root-path`.
Therefore setting the following properties
```properties
quarkus.http.non-application-root-path=/foo
quarkus.http.root-path=/bar
```
no longer add the path `/foo/` to the ignored paths.
However if the following properties are set
```properties
quarkus.http.non-application-root-path=/app/q
quarkus.http.root-path=/app
```
then `/q/` would be added to the ignored paths (and not `/app/q/`).
Note that `quarkus.resteasy.path` and `quarkus.rest.path` are always relative to `quarkus.http.root-path` even if they start with a slash (`/`).

<!--  If your PR fixes an open issue then use Closes #31 -->
## Fixes Issue
Fixes #302
 
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--

[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done -->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

I assume the documentation is automatically updated by the `.adoc` files or is there any manual step for updating the documentation for changes in config documentation?

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
