### PR TITLE
Fix #682: 2.3.x Allow to define if dev-server is HTTPS / TLS

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/DevServerConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/DevServerConfig.java
@@ -41,13 +41,13 @@ public interface DevServerConfig {
     String host();
 
     /**
-     * Protocol of the server to forward requests to.
+     * When set to true, Quinoa requests will be forwarded with tls enabled.
      */
     @WithDefault("false")
     boolean tls();
 
     /**
-     * Protocol of the server to forward requests to.
+     * When set to true, Quinoa will accept any certificate with any hostname.
      */
     @WithDefault("false")
     boolean tlsAllowInsecure();

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/items/ForwardedDevServerBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/items/ForwardedDevServerBuildItem.java
@@ -4,12 +4,24 @@ import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class ForwardedDevServerBuildItem extends SimpleBuildItem {
 
+    private final boolean tls;
+    private final boolean tlsAllowInsecure;
     private final String host;
     private final Integer port;
 
-    public ForwardedDevServerBuildItem(String host, Integer port) {
+    public ForwardedDevServerBuildItem(boolean tls, boolean tlsAllowInsecure, String host, Integer port) {
+        this.tls = tls;
+        this.tlsAllowInsecure = tlsAllowInsecure;
         this.host = host;
         this.port = port;
+    }
+
+    public boolean isTls() {
+        return tls;
+    }
+
+    public boolean isTlsAllowInsecure() {
+        return tlsAllowInsecure;
     }
 
     public String getHost() {

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,5 +1,5 @@
 :quarkus-version: 3.8.2
-:quarkus-quinoa-version: 2.3.7
+:quarkus-quinoa-version: 2.3.8
 :maven-version: 3.8.1+
 :extension-status: stable
 

--- a/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
@@ -571,6 +571,40 @@ endif::add-copy-button-to-env-var[]
 |`localhost`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-dev-server-tls]]`link:#quarkus-quinoa_quarkus-quinoa-dev-server-tls[quarkus.quinoa.dev-server.tls]`
+
+
+[.description]
+--
+When set to true, Quinoa requests will be forwarded with tls enabled.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_DEV_SERVER_TLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_QUINOA_DEV_SERVER_TLS+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-dev-server-tls-allow-insecure]]`link:#quarkus-quinoa_quarkus-quinoa-dev-server-tls-allow-insecure[quarkus.quinoa.dev-server.tls-allow-insecure]`
+
+
+[.description]
+--
+When set to true, Quinoa will accept any certificate with any hostname.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_DEV_SERVER_TLS_ALLOW_INSECURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_QUINOA_DEV_SERVER_TLS_ALLOW_INSECURE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-dev-server-check-path]]`link:#quarkus-quinoa_quarkus-quinoa-dev-server-check-path[quarkus.quinoa.dev-server.check-path]`
 
 

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java
@@ -20,6 +20,7 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
 
 class QuinoaDevProxyHandler implements Handler<RoutingContext> {
     private static final Logger LOG = Logger.getLogger(QuinoaDevProxyHandler.class);
@@ -36,11 +37,20 @@ class QuinoaDevProxyHandler implements Handler<RoutingContext> {
     private final ClassLoader currentClassLoader;
     private final QuinoaHandlerConfig config;
 
-    QuinoaDevProxyHandler(final QuinoaHandlerConfig config, final Vertx vertx, String host, int port,
+    QuinoaDevProxyHandler(final QuinoaHandlerConfig config, final Vertx vertx, boolean tls, boolean tlsAllowInsecure,
+            String host, int port,
             boolean websocket) {
         this.host = host;
         this.port = port;
-        this.client = WebClient.create(vertx);
+        WebClientOptions options = new WebClientOptions();
+        if (tls) {
+            options.setSsl(true);
+            if (tlsAllowInsecure) {
+                options.setTrustAll(true);
+                options.setVerifyHost(false);
+            }
+        }
+        this.client = WebClient.create(vertx, options);
         this.wsUpgradeHandler = websocket ? new QuinoaDevWebSocketProxyHandler(vertx, host, port) : null;
         this.config = config;
         currentClassLoader = Thread.currentThread().getContextClassLoader();

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
@@ -26,9 +26,9 @@ public class QuinoaRecorder {
     public static final Set<HttpMethod> HANDLED_METHODS = Set.of(HttpMethod.HEAD, HttpMethod.OPTIONS, HttpMethod.GET);
 
     public Handler<RoutingContext> quinoaProxyDevHandler(final QuinoaHandlerConfig handlerConfig, Supplier<Vertx> vertx,
-            String host, int port, boolean websocket) {
+            boolean tls, boolean tlsAllowInsecure, String host, int port, boolean websocket) {
         logIgnoredPathPrefixes(handlerConfig.ignoredPathPrefixes);
-        return new QuinoaDevProxyHandler(handlerConfig, vertx.get(), host, port, websocket);
+        return new QuinoaDevProxyHandler(handlerConfig, vertx.get(), tls, tlsAllowInsecure, host, port, websocket);
     }
 
     public Handler<RoutingContext> quinoaSPARoutingHandler(final QuinoaHandlerConfig handlerConfig) throws IOException {


### PR DESCRIPTION
Backport Fix #682: 2.3.x Allow to define if dev-server is HTTPS / TLS