### PR TITLE
[2.3.x] Add root path for Quinoa Web UI

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
@@ -50,6 +50,8 @@ import io.quarkus.dev.console.QuarkusConsole;
 import io.quarkus.resteasy.reactive.server.spi.ResumeOn404BuildItem;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
+import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.WebsocketSubProtocolsBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
@@ -194,6 +196,8 @@ public class ForwardedDevProcessor {
             Optional<ForwardedDevServerBuildItem> devProxy,
             Optional<ConfiguredQuinoaBuildItem> configuredQuinoa,
             CoreVertxBuildItem vertx,
+            HttpRootPathBuildItem httpRootPath,
+            NonApplicationRootPathBuildItem nonApplicationRootPath,
             BuildProducer<RouteBuildItem> routes,
             BuildProducer<WebsocketSubProtocolsBuildItem> websocketSubProtocols,
             BuildProducer<ResumeOn404BuildItem> resumeOn404) throws IOException {
@@ -205,8 +209,12 @@ public class ForwardedDevProcessor {
                 return;
             }
             LOG.infof("Quinoa is forwarding unhandled requests to port: %d", devProxy.get().getPort());
-            final QuinoaHandlerConfig handlerConfig = toHandlerConfig(quinoaConfig, true, httpBuildTimeConfig);
-            routes.produce(RouteBuildItem.builder().orderedRoute("/*", QUINOA_ROUTE_ORDER)
+            final QuinoaHandlerConfig handlerConfig = toHandlerConfig(quinoaConfig, true, httpBuildTimeConfig,
+                    nonApplicationRootPath);
+            String uiRootPath = QuinoaConfig.getNormalizedUiRootPath(quinoaConfig);
+            recorder.logUiRootPath(httpRootPath.relativePath(uiRootPath));
+            // note that the uiRootPath is resolved relative to 'quarkus.http.root-path' by the RouteBuildItem
+            routes.produce(RouteBuildItem.builder().orderedRoute(uiRootPath + "*", QUINOA_ROUTE_ORDER)
                     .handler(recorder.quinoaProxyDevHandler(handlerConfig, vertx.getVertx(), devProxy.get().isTls(),
                             devProxy.get().isTlsAllowInsecure(), devProxy.get().getHost(),
                             devProxy.get().getPort(),
@@ -217,7 +225,7 @@ public class ForwardedDevProcessor {
             }
             if (quinoaConfig.enableSPARouting()) {
                 resumeOn404.produce(new ResumeOn404BuildItem());
-                routes.produce(RouteBuildItem.builder().orderedRoute("/*", QUINOA_SPA_ROUTE_ORDER)
+                routes.produce(RouteBuildItem.builder().orderedRoute(uiRootPath + "*", QUINOA_SPA_ROUTE_ORDER)
                         .handler(recorder.quinoaSPARoutingHandler(handlerConfig))
                         .build());
             }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
@@ -212,7 +212,9 @@ public class ForwardedDevProcessor {
             final QuinoaHandlerConfig handlerConfig = toHandlerConfig(quinoaConfig, true, httpBuildTimeConfig,
                     nonApplicationRootPath);
             String uiRootPath = QuinoaConfig.getNormalizedUiRootPath(quinoaConfig);
-            recorder.logUiRootPath(httpRootPath.relativePath(uiRootPath));
+            // the resolvedUiRootPath is only used for logging
+            String resolvedUiRootPath = httpRootPath.relativePath(uiRootPath);
+            recorder.logUiRootPath(resolvedUiRootPath.endsWith("/") ? resolvedUiRootPath : resolvedUiRootPath + "/");
             // note that the uiRootPath is resolved relative to 'quarkus.http.root-path' by the RouteBuildItem
             routes.produce(RouteBuildItem.builder().orderedRoute(uiRootPath + "*", QUINOA_ROUTE_ORDER)
                     .handler(recorder.quinoaProxyDevHandler(handlerConfig, vertx.getVertx(), devProxy.get().isTls(),

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -269,7 +269,9 @@ public class QuinoaProcessor {
                     nonApplicationRootPath);
             resumeOn404.produce(new ResumeOn404BuildItem());
             String uiRootPath = QuinoaConfig.getNormalizedUiRootPath(configuredQuinoa.resolvedConfig());
-            recorder.logUiRootPath(httpRootPath.relativePath(uiRootPath));
+            // the resolvedUiRootPath is only used for logging
+            String resolvedUiRootPath = httpRootPath.relativePath(uiRootPath);
+            recorder.logUiRootPath(resolvedUiRootPath.endsWith("/") ? resolvedUiRootPath : resolvedUiRootPath + "/");
             // note that the uiRootPath is resolved relative to 'quarkus.http.root-path' by the RouteBuildItem
             routes.produce(RouteBuildItem.builder().orderedRoute(uiRootPath + "*", QUINOA_ROUTE_ORDER)
                     .handler(recorder.quinoaHandler(handlerConfig, directory,

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -57,6 +57,8 @@ import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.resteasy.reactive.server.spi.ResumeOn404BuildItem;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 
@@ -247,6 +249,8 @@ public class QuinoaProcessor {
             HttpBuildTimeConfig httpBuildTimeConfig,
             LaunchModeBuildItem launchMode,
             Optional<BuiltResourcesBuildItem> uiResources,
+            HttpRootPathBuildItem httpRootPath,
+            NonApplicationRootPathBuildItem nonApplicationRootPath,
             QuinoaRecorder recorder,
             BuildProducer<RouteBuildItem> routes,
             BuildProducer<ResumeOn404BuildItem> resumeOn404) throws IOException {
@@ -261,14 +265,18 @@ public class QuinoaProcessor {
             }
             final QuinoaHandlerConfig handlerConfig = toHandlerConfig(configuredQuinoa.resolvedConfig(),
                     launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT,
-                    httpBuildTimeConfig);
+                    httpBuildTimeConfig,
+                    nonApplicationRootPath);
             resumeOn404.produce(new ResumeOn404BuildItem());
-            routes.produce(RouteBuildItem.builder().orderedRoute("/*", QUINOA_ROUTE_ORDER)
+            String uiRootPath = QuinoaConfig.getNormalizedUiRootPath(configuredQuinoa.resolvedConfig());
+            recorder.logUiRootPath(httpRootPath.relativePath(uiRootPath));
+            // note that the uiRootPath is resolved relative to 'quarkus.http.root-path' by the RouteBuildItem
+            routes.produce(RouteBuildItem.builder().orderedRoute(uiRootPath + "*", QUINOA_ROUTE_ORDER)
                     .handler(recorder.quinoaHandler(handlerConfig, directory,
                             uiResources.get().getNames()))
                     .build());
             if (configuredQuinoa.resolvedConfig().enableSPARouting()) {
-                routes.produce(RouteBuildItem.builder().orderedRoute("/*", QUINOA_SPA_ROUTE_ORDER)
+                routes.produce(RouteBuildItem.builder().orderedRoute(uiRootPath + "*", QUINOA_SPA_ROUTE_ORDER)
                         .handler(recorder.quinoaSPARoutingHandler(handlerConfig))
                         .build());
             }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
@@ -211,7 +211,8 @@ public interface QuinoaConfig {
                 .map(s -> normalizePath(s, true))
                 // only add this path if it is relative to the ui-root-path
                 .flatMap(s -> relativizePath(uiRootPath, s))
-                .filter(s -> !Objects.equals(s, "/"));
+                .filter(s -> !Objects.equals(s, "/"))
+                .map(s -> s.endsWith("/") ? s.substring(0, s.length() - 1) : s);
     }
 
     private static Optional<String> convertNonApplicationRootPath(String uiRootPath,
@@ -222,7 +223,8 @@ public interface QuinoaConfig {
                 nonApplicationRootPath.getNonApplicationRootPath())
                 // and also only add this path if it is relative to the ui-root-path
                 .flatMap(s -> relativizePath(uiRootPath, s))
-                .filter(s -> !Objects.equals(s, "/"));
+                .filter(s -> !Objects.equals(s, "/"))
+                .map(s -> s.endsWith("/") ? s.substring(0, s.length() - 1) : s);
     }
 
     static boolean isDevServerMode(QuinoaConfig config) {

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
@@ -1,20 +1,21 @@
 package io.quarkiverse.quinoa.deployment.config;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkiverse.quinoa.QuinoaHandlerConfig;
+import io.quarkus.deployment.util.UriNormalizationUtil;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
@@ -26,6 +27,7 @@ import io.smallrye.config.WithParentName;
 public interface QuinoaConfig {
 
     String DEFAULT_BUILD_DIR = "build/";
+    String DEFAULT_WEB_UI_ROOT_PATH = "/";
     String DEFAULT_WEB_UI_DIR = "src/main/webui";
     String DEFAULT_INDEX_PAGE = "index.html";
 
@@ -45,6 +47,13 @@ public interface QuinoaConfig {
      */
     @WithDefault("false")
     boolean justBuild();
+
+    /**
+     * Root path for hosting the Web UI.
+     * This path is normalized and always resolved relative to 'quarkus.http.root-path'.
+     */
+    @WithDefault(DEFAULT_WEB_UI_ROOT_PATH)
+    String uiRootPath();
 
     /**
      * Path to the Web UI (NodeJS) root directory (relative to the project root).
@@ -121,6 +130,7 @@ public interface QuinoaConfig {
 
     /**
      * List of path prefixes to be ignored by Quinoa.
+     * The paths are normalized and always resolved relative to 'quarkus.quinoa.ui-root-path'.
      */
     @ConfigDocDefault("ignore values configured by 'quarkus.resteasy-reactive.path', 'quarkus.resteasy.path' and 'quarkus.http.non-application-root-path'")
     Optional<List<String>> ignoredPathPrefixes();
@@ -130,23 +140,62 @@ public interface QuinoaConfig {
      */
     DevServerConfig devServer();
 
-    static List<String> getNormalizedIgnoredPathPrefixes(QuinoaConfig config) {
-        return config.ignoredPathPrefixes().orElseGet(() -> {
-            Config allConfig = ConfigProvider.getConfig();
-            List<String> defaultIgnore = new ArrayList<>();
-            readExternalConfigPath(allConfig, "quarkus.resteasy.path").ifPresent(defaultIgnore::add);
-            readExternalConfigPath(allConfig, "quarkus.resteasy-reactive.path").ifPresent(defaultIgnore::add);
-            readExternalConfigPath(allConfig, "quarkus.http.non-application-root-path").ifPresent(defaultIgnore::add);
-            return defaultIgnore;
-        }).stream().map(s -> s.startsWith("/") ? s : "/" + s).collect(toList());
+    static List<String> getNormalizedIgnoredPathPrefixes(QuinoaConfig config,
+            NonApplicationRootPathBuildItem nonApplicationRootPath) {
+        return config.ignoredPathPrefixes()
+                .map(list -> list.stream()
+                        .map(s -> normalizePath(s, false))
+                        .collect(Collectors.toList()))
+                .orElseGet(() -> {
+                    Config allConfig = ConfigProvider.getConfig();
+                    List<String> defaultIgnore = new ArrayList<>();
+                    String uiRootPath = getNormalizedUiRootPath(config);
+                    // note that quarkus.resteasy.path and quarkus.resteasy-reactive.path are always relative to the http root path
+                    readExternalConfigPath(uiRootPath, allConfig, "quarkus.resteasy.path").ifPresent(defaultIgnore::add);
+                    readExternalConfigPath(uiRootPath, allConfig, "quarkus.resteasy-reactive.path")
+                            .ifPresent(defaultIgnore::add);
+                    // the non-application root path is not always relative to the http root path
+                    convertNonApplicationRootPath(uiRootPath, nonApplicationRootPath).ifPresent(defaultIgnore::add);
+                    return defaultIgnore;
+                });
+    }
+
+    /**
+     * <p>
+     * Normalizes the {@link QuinoaConfig#uiRootPath()} and the returned path always starts with {@code "/"} and ends with
+     * {@code "/"}.
+     * <p>
+     * Note that this will not resolve the path relative to 'quarkus.http.root-path'.
+     */
+    static String getNormalizedUiRootPath(QuinoaConfig config) {
+        return normalizePath(config.uiRootPath(), true);
     }
 
     static QuinoaHandlerConfig toHandlerConfig(QuinoaConfig config, boolean devMode,
-            final HttpBuildTimeConfig httpBuildTimeConfig) {
+            final HttpBuildTimeConfig httpBuildTimeConfig, NonApplicationRootPathBuildItem nonApplicationRootPath) {
         final Set<String> compressMediaTypes = httpBuildTimeConfig.compressMediaTypes.map(Set::copyOf).orElse(Set.of());
         final String indexPage = resolveIndexPage(config, devMode);
-        return new QuinoaHandlerConfig(getNormalizedIgnoredPathPrefixes(config), indexPage, devMode,
+        return new QuinoaHandlerConfig(getNormalizedIgnoredPathPrefixes(config, nonApplicationRootPath), indexPage, devMode,
                 httpBuildTimeConfig.enableCompression, compressMediaTypes, config.devServer().directForwarding());
+    }
+
+    /**
+     * Normalizes the path and the returned path starts with a slash and if {@code trailingSlash} is set to {@code true} then it
+     * will also end in a slash.
+     */
+    private static String normalizePath(String path, boolean trailingSlash) {
+        String normalizedPath = UriNormalizationUtil.toURI(path, trailingSlash).getPath();
+        return normalizedPath.startsWith("/") ? normalizedPath : "/" + normalizedPath;
+    }
+
+    /**
+     * Note that {@code rootPath} and {@code leafPath} are required to start and end in a slash.
+     * The returned path also fulfills this requirement.
+     */
+    private static Optional<String> relativizePath(String rootPath, String leafPath) {
+        return Optional.ofNullable(UriNormalizationUtil.relativize(rootPath, leafPath))
+                // note that relativize always removes the leading slash
+                .map(s -> "/" + s);
     }
 
     private static String resolveIndexPage(QuinoaConfig config, boolean devMode) {
@@ -157,10 +206,23 @@ public interface QuinoaConfig {
         return isDevServerMode(config) ? config.devServer().indexPage().orElse(config.indexPage()) : config.indexPage();
     }
 
-    private static Optional<String> readExternalConfigPath(Config config, String key) {
+    private static Optional<String> readExternalConfigPath(String uiRootPath, Config config, String key) {
         return config.getOptionalValue(key, String.class)
-                .filter(s -> !Objects.equals(s, "/"))
-                .map(s -> s.endsWith("/") ? s : s + "/");
+                .map(s -> normalizePath(s, true))
+                // only add this path if it is relative to the ui-root-path
+                .flatMap(s -> relativizePath(uiRootPath, s))
+                .filter(s -> !Objects.equals(s, "/"));
+    }
+
+    private static Optional<String> convertNonApplicationRootPath(String uiRootPath,
+            NonApplicationRootPathBuildItem nonApplicationRootPath) {
+        // only add the non-application root path if it is relative to the http root path
+        // note that both paths start and end in a slash already
+        return relativizePath(nonApplicationRootPath.getNormalizedHttpRootPath(),
+                nonApplicationRootPath.getNonApplicationRootPath())
+                // and also only add this path if it is relative to the ui-root-path
+                .flatMap(s -> relativizePath(uiRootPath, s))
+                .filter(s -> !Objects.equals(s, "/"));
     }
 
     static boolean isDevServerMode(QuinoaConfig config) {
@@ -176,6 +238,9 @@ public interface QuinoaConfig {
             return false;
         }
         if (!Objects.equals(q1.justBuild(), q2.justBuild())) {
+            return false;
+        }
+        if (!Objects.equals(q1.uiRootPath(), q2.uiRootPath())) {
             return false;
         }
         if (!Objects.equals(q1.uiDir(), q2.uiDir())) {

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/delegate/QuinoaConfigDelegate.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/delegate/QuinoaConfigDelegate.java
@@ -27,6 +27,11 @@ public class QuinoaConfigDelegate implements QuinoaConfig {
     }
 
     @Override
+    public String uiRootPath() {
+        return delegate.uiRootPath();
+    }
+
+    @Override
     public String uiDir() {
         return delegate.uiDir();
     }

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaAbsoluteUIDirTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaAbsoluteUIDirTest.java
@@ -25,7 +25,7 @@ public class QuinoaAbsoluteUIDirTest {
                         .anyMatch(s -> s.getMessage().equals("Running Quinoa package manager build command: %s") &&
                                 s.getParameters()[0].equals(systemBinary("npm") + " run build"));
                 assertThat(l)
-                        .anyMatch(s -> s.getMessage().equals("Quinoa is ignoring paths starting with: /q/"));
+                        .anyMatch(s -> s.getMessage().equals("Quinoa is ignoring paths starting with: /q"));
             });
 
     static {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaDefaultConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaDefaultConfigTest.java
@@ -24,7 +24,7 @@ public class QuinoaDefaultConfigTest {
                         .anyMatch(s -> s.getMessage().equals("Running Quinoa package manager build command: %s") &&
                                 s.getParameters()[0].equals(systemBinary("npm") + " run build"));
                 assertThat(l)
-                        .anyMatch(s -> s.getMessage().equals("Quinoa is ignoring paths starting with: /q/"));
+                        .anyMatch(s -> s.getMessage().equals("Quinoa is ignoring paths starting with: /q"));
             });
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
@@ -11,21 +11,25 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class QuinoaPathPrefixesRESTConfigTest {
+public class QuinoaPathPrefixesRESTConfigRelativeRootPathTest {
 
-    private static final String NAME = "resteasy-reactive-path-config";
+    private static final String NAME = "resteasy-reactive-path-config-relative-root-path";
 
     @RegisterExtension
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create(NAME)
             .toQuarkusUnitTest()
-            .overrideConfigKey("quarkus.resteasy-reactive.path", "/foo/reactive")
-            .overrideConfigKey("quarkus.resteasy.path", "/foo/classic")
-            .overrideConfigKey("quarkus.http.non-application-root-path", "/bar/non")
+            .overrideConfigKey("quarkus.http.root-path", "root/path")
+            .overrideConfigKey("quarkus.resteasy-reactive.path", "foo/reactive")
+            .overrideConfigKey("quarkus.resteasy.path", "foo/classic")
+            .overrideConfigKey("quarkus.http.non-application-root-path", "bar/non")
             .assertLogRecords(l -> assertThat(l)
                     .anyMatch(s -> s.getMessage()
+                            // note how /bar/non is part of the ignored paths
+                            // this is because bar/non is relative to the root path when it does not start with a slash
+                            // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
                             .equals("Quinoa is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /")));
+                            .equals("Quinoa is available at: /root/path")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
@@ -29,7 +29,7 @@ public class QuinoaPathPrefixesRESTConfigRelativeRootPathTest {
                             // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
                             .equals("Quinoa is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /root/path")));
+                            .equals("Quinoa is available at: /root/path/")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRelativeRootPathTest.java
@@ -27,7 +27,7 @@ public class QuinoaPathPrefixesRESTConfigRelativeRootPathTest {
                             // note how /bar/non is part of the ignored paths
                             // this is because bar/non is relative to the root path when it does not start with a slash
                             // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
-                            .equals("Quinoa is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
+                            .equals("Quinoa is ignoring paths starting with: /foo/classic, /foo/reactive, /bar/non"))
                     .anyMatch(s -> s.getMessage()
                             .equals("Quinoa is available at: /root/path/")));
 

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
@@ -11,21 +11,25 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class QuinoaPathPrefixesRESTConfigTest {
+public class QuinoaPathPrefixesRESTConfigRootPathTest {
 
-    private static final String NAME = "resteasy-reactive-path-config";
+    private static final String NAME = "resteasy-reactive-path-config-root-path";
 
     @RegisterExtension
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create(NAME)
             .toQuarkusUnitTest()
+            .overrideConfigKey("quarkus.http.root-path", "/root/path")
             .overrideConfigKey("quarkus.resteasy-reactive.path", "/foo/reactive")
             .overrideConfigKey("quarkus.resteasy.path", "/foo/classic")
             .overrideConfigKey("quarkus.http.non-application-root-path", "/bar/non")
             .assertLogRecords(l -> assertThat(l)
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
+                            // note how /bar/non is not part of the ignored paths
+                            // this is because /bar/non is not relative to /root/path
+                            // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
+                            .equals("Quinoa is ignoring paths starting with: /foo/classic/, /foo/reactive/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /")));
+                            .equals("Quinoa is available at: /root/path")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
@@ -29,7 +29,7 @@ public class QuinoaPathPrefixesRESTConfigRootPathTest {
                             // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
                             .equals("Quinoa is ignoring paths starting with: /foo/classic/, /foo/reactive/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /root/path")));
+                            .equals("Quinoa is available at: /root/path/")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigRootPathTest.java
@@ -27,7 +27,7 @@ public class QuinoaPathPrefixesRESTConfigRootPathTest {
                             // note how /bar/non is not part of the ignored paths
                             // this is because /bar/non is not relative to /root/path
                             // also note that quarkus.rest.path, and quarkus.resteasy.path are always relative to the root path even if they start with a slash
-                            .equals("Quinoa is ignoring paths starting with: /foo/classic/, /foo/reactive/"))
+                            .equals("Quinoa is ignoring paths starting with: /foo/classic, /foo/reactive"))
                     .anyMatch(s -> s.getMessage()
                             .equals("Quinoa is available at: /root/path/")));
 

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigTest.java
@@ -23,7 +23,7 @@ public class QuinoaPathPrefixesRESTConfigTest {
             .overrideConfigKey("quarkus.http.non-application-root-path", "/bar/non")
             .assertLogRecords(l -> assertThat(l)
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
+                            .equals("Quinoa is ignoring paths starting with: /foo/classic, /foo/reactive, /bar/non"))
                     .anyMatch(s -> s.getMessage()
                             .equals("Quinoa is available at: /")));
 

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
@@ -28,7 +28,7 @@ public class QuinoaPathPrefixesRESTConfigUiRootPathTest {
                             // ignored paths are always relative to the ui root path
                             .equals("Quinoa is ignoring paths starting with: /classic/, /reactive/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /root/path/foo")));
+                            .equals("Quinoa is available at: /root/path/foo/")));
 
     @Test
     public void testQuinoa() {

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
@@ -26,7 +26,7 @@ public class QuinoaPathPrefixesRESTConfigUiRootPathTest {
             .assertLogRecords(l -> assertThat(l)
                     .anyMatch(s -> s.getMessage()
                             // ignored paths are always relative to the ui root path
-                            .equals("Quinoa is ignoring paths starting with: /classic/, /reactive/"))
+                            .equals("Quinoa is ignoring paths starting with: /classic, /reactive"))
                     .anyMatch(s -> s.getMessage()
                             .equals("Quinoa is available at: /root/path/foo/")));
 

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaPathPrefixesRESTConfigUiRootPathTest.java
@@ -11,21 +11,24 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class QuinoaPathPrefixesRESTConfigTest {
+public class QuinoaPathPrefixesRESTConfigUiRootPathTest {
 
-    private static final String NAME = "resteasy-reactive-path-config";
+    private static final String NAME = "resteasy-reactive-path-config-ui-root-path";
 
     @RegisterExtension
     static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create(NAME)
             .toQuarkusUnitTest()
+            .overrideConfigKey("quarkus.http.root-path", "/root/path")
+            .overrideConfigKey("quarkus.quinoa.ui-root-path", "/foo")
             .overrideConfigKey("quarkus.resteasy-reactive.path", "/foo/reactive")
             .overrideConfigKey("quarkus.resteasy.path", "/foo/classic")
             .overrideConfigKey("quarkus.http.non-application-root-path", "/bar/non")
             .assertLogRecords(l -> assertThat(l)
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is ignoring paths starting with: /foo/classic/, /foo/reactive/, /bar/non/"))
+                            // ignored paths are always relative to the ui root path
+                            .equals("Quinoa is ignoring paths starting with: /classic/, /reactive/"))
                     .anyMatch(s -> s.getMessage()
-                            .equals("Quinoa is available at: /")));
+                            .equals("Quinoa is available at: /root/path/foo")));
 
     @Test
     public void testQuinoa() {

--- a/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-quinoa.adoc
@@ -44,6 +44,23 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-ui-root-path]]`link:#quarkus-quinoa_quarkus-quinoa-ui-root-path[quarkus.quinoa.ui-root-path]`
+
+
+[.description]
+--
+Root path for hosting the Web UI. This path is normalized and always resolved relative to 'quarkus.http.root-path'.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_UI_ROOT_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_QUINOA_UI_ROOT_PATH+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`/`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-ui-dir]]`link:#quarkus-quinoa_quarkus-quinoa-ui-dir[quarkus.quinoa.ui-dir]`
 
 
@@ -491,7 +508,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-quinoa_quarkus-quinoa-ignored-p
 
 [.description]
 --
-List of path prefixes to be ignored by Quinoa.
+List of path prefixes to be ignored by Quinoa. The paths are normalized and always resolved relative to 'quarkus.quinoa.ui-root-path'.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_QUINOA_IGNORED_PATH_PREFIXES+++[]

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,6 +1,12 @@
-%lit-root-path.quarkus.http.root-path=/foo/bar
-%lit-root-path.quarkus.quinoa.enable-spa-routing=true
-%lit-root-path.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/foo/bar/
+%lit-root-path,lit-ui-root-path.quarkus.http.root-path=/foo/bar
+%lit-root-path,lit-ui-root-path.quarkus.quinoa.enable-spa-routing=true
+%lit-root-path,lit-ui-root-path.quarkus.quinoa.package-manager-command.build-env.API_PATH=/foo/bar/api/
+
+%lit-root-path.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/foo/bar
+
+%lit-ui-root-path.quarkus.quinoa.ui-root-path=/ui
+%lit-ui-root-path.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/foo/bar/ui
+%lit-ui-root-path.quarkus.quinoa.ignored-path-prefixes=/ignored
 
 quarkus.quinoa.ui-dir=src/main/ui-react
 %react.quarkus.quinoa.ui-dir=src/main/ui-react
@@ -13,13 +19,14 @@ quarkus.quinoa.ui-dir=src/main/ui-react
 %angular.quarkus.quinoa.package-manager-install.install-dir=target/
 %angular.quarkus.quinoa.package-manager-install.node-version=20.9.0
 %angular.quarkus.quinoa.package-manager-install.yarn-version=1.22.19
-%lit,lit-root-path.quarkus.quinoa.ui-dir=src/main/ui-lit
-%lit,lit-root-path.quarkus.quinoa.build-dir=dist
-%lit,lit-root-path.quarkus.quinoa.index-page=app.html
-%lit,lit-root-path.quarkus.quinoa.package-manager-command.build=run build-per-env
-%lit-root-path.quarkus.quinoa.package-manager-command.build-env.FOO=bar
+%lit,lit-root-path,lit-ui-root-path.quarkus.quinoa.ui-dir=src/main/ui-lit
+%lit,lit-root-path,lit-ui-root-path.quarkus.quinoa.build-dir=dist
+%lit,lit-root-path,lit-ui-root-path.quarkus.quinoa.index-page=app.html
+%lit,lit-root-path,lit-ui-root-path.quarkus.quinoa.package-manager-command.build=run build-per-env
+%lit-root-path,lit-ui-root-path.quarkus.quinoa.package-manager-command.build-env.FOO=bar
 %lit.quarkus.quinoa.package-manager-command.build-env.FOO=bar
 %lit.quarkus.quinoa.package-manager-command.build-env.ROOT_PATH=/
+%lit.quarkus.quinoa.package-manager-command.build-env.API_PATH=/api/
 
 %yarn.quarkus.quinoa.package-manager=yarn
 %just-build.quarkus.quinoa.just-build=true

--- a/integration-tests/src/main/ui-lit/src/simple-greeting.js
+++ b/integration-tests/src/main/ui-lit/src/simple-greeting.js
@@ -1,6 +1,6 @@
 import {html, css, LitElement} from 'lit';
 
-const ROOT_PATH = process.env.ROOT_PATH;
+const API_PATH = process.env.API_PATH;
 
 export class SimpleGreeting extends LitElement {
     static styles = css`p { color: blue }`;
@@ -17,7 +17,7 @@ export class SimpleGreeting extends LitElement {
     render() {
         const xmlHttp = new XMLHttpRequest();
 
-        xmlHttp.open( "GET", `${ROOT_PATH}api/quinoa`, false );
+        xmlHttp.open( "GET", `${API_PATH}quinoa`, false );
         xmlHttp.send( null );
         const response = xmlHttp.responseText;
         return html`<p class="greeting">${response} and ${this.name} and ${process.env.FOO}</p>`;

--- a/integration-tests/src/main/ui-lit/webpack.config.js
+++ b/integration-tests/src/main/ui-lit/webpack.config.js
@@ -12,6 +12,6 @@ module.exports = {
                 { from: 'public' }
             ]
         }),
-        new EnvironmentPlugin(['FOO', 'ROOT_PATH'])
+        new EnvironmentPlugin(['FOO', 'ROOT_PATH', 'API_PATH'])
     ]
 };

--- a/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaUiRootPathTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaUiRootPathTest.java
@@ -1,0 +1,88 @@
+package io.quarkiverse.quinoa.it;
+
+import static io.restassured.RestAssured.given;
+
+import java.net.URL;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.ElementHandle;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Response;
+
+import io.quarkiverse.playwright.InjectPlaywright;
+import io.quarkiverse.playwright.WithPlaywright;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(TestProfiles.UiRootPathTests.class)
+@WithPlaywright
+public class QuinoaUiRootPathTest {
+
+    @InjectPlaywright
+    BrowserContext context;
+
+    @TestHTTPResource("/")
+    URL urlRoot;
+
+    @TestHTTPResource("/ui/ignored")
+    URL url404Ignored;
+
+    @TestHTTPResource("/ui")
+    URL url;
+
+    @TestHTTPResource("/ui/some-route")
+    URL urlRoute;
+
+    @Test
+    public void testRoot() {
+        // the root is the index.html in /META-INF/resources and not Quinoa
+        given()
+                .when().get(urlRoot)
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("NOT QUINOA"));
+    }
+
+    @Test
+    public void test404Endpoint() {
+        given()
+                .when().get(url404Ignored)
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testUIIndex() {
+        final Page page = context.newPage();
+        Response response = page.navigate(url.toString());
+        Assertions.assertEquals("OK", response.statusText());
+
+        page.waitForLoadState();
+
+        String title = page.title();
+        Assertions.assertEquals("Quinoa Lit App", title);
+
+        // Make sure the component loaded and hits the backend
+        final ElementHandle quinoaEl = page.waitForSelector(".greeting");
+        String greeting = quinoaEl.innerText();
+        Assertions.assertEquals("Hello Quinoa and World and bar", greeting);
+    }
+
+    @Test
+    public void testRoute() {
+        final Page page = context.newPage();
+        Response response = page.navigate(urlRoute.toString());
+        Assertions.assertEquals("OK", response.statusText());
+
+        page.waitForLoadState();
+
+        String title = page.title();
+        Assertions.assertEquals("Quinoa Lit App", title);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaUiRootPathTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/quinoa/it/QuinoaUiRootPathTest.java
@@ -33,6 +33,13 @@ public class QuinoaUiRootPathTest {
     @TestHTTPResource("/ui/ignored")
     URL url404Ignored;
 
+    @TestHTTPResource("/ui/ignored/sub-path")
+    URL url404IgnoredSubPath;
+
+    // this path starts with /ignored, but is not a sub path of /ignored
+    @TestHTTPResource("/ui/ignored-not-ignored")
+    URL urlNotIgnored;
+
     @TestHTTPResource("/ui")
     URL url;
 
@@ -53,6 +60,10 @@ public class QuinoaUiRootPathTest {
     public void test404Endpoint() {
         given()
                 .when().get(url404Ignored)
+                .then()
+                .statusCode(404);
+        given()
+                .when().get(url404IgnoredSubPath)
                 .then()
                 .statusCode(404);
     }
@@ -78,6 +89,18 @@ public class QuinoaUiRootPathTest {
     public void testRoute() {
         final Page page = context.newPage();
         Response response = page.navigate(urlRoute.toString());
+        Assertions.assertEquals("OK", response.statusText());
+
+        page.waitForLoadState();
+
+        String title = page.title();
+        Assertions.assertEquals("Quinoa Lit App", title);
+    }
+
+    @Test
+    public void testNotIgnored() {
+        final Page page = context.newPage();
+        Response response = page.navigate(urlNotIgnored.toString());
         Assertions.assertEquals("OK", response.statusText());
 
         page.waitForLoadState();

--- a/integration-tests/src/test/java/io/quarkiverse/quinoa/it/TestProfiles.java
+++ b/integration-tests/src/test/java/io/quarkiverse/quinoa/it/TestProfiles.java
@@ -46,6 +46,13 @@ public class TestProfiles {
         }
     }
 
+    public static class UiRootPathTests extends QuinoaTestProfiles.Enable {
+        @Override
+        public String getConfigProfile() {
+            return "lit-ui-root-path";
+        }
+    }
+
     public static class VueTests extends QuinoaTestProfiles.Enable {
         @Override
         public String getConfigProfile() {

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaRecorder.java
@@ -4,6 +4,7 @@ import static io.quarkus.vertx.http.runtime.RouteConstants.ROUTE_ORDER_DEFAULT;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -63,8 +64,18 @@ public class QuinoaRecorder {
         return resolvedPath.isEmpty() ? "/" : resolvedPath;
     }
 
+    static boolean matchesPathSeparatedPrefix(String path, String pathSeparatedPrefix) {
+        if (path.startsWith(pathSeparatedPrefix)) {
+            String restPath = path.substring(pathSeparatedPrefix.length());
+            // the path matches the path separated prefix if the rest path is empty or starts with "/"
+            // note that the pathSeparatedPrefix never ends in "/" except if it equals "/" exactly
+            return restPath.isEmpty() || restPath.startsWith("/") || Objects.equals(pathSeparatedPrefix, "/");
+        }
+        return false;
+    }
+
     static boolean isIgnored(final String path, final List<String> ignoredPathPrefixes) {
-        if (ignoredPathPrefixes.stream().anyMatch(path::startsWith)) {
+        if (ignoredPathPrefixes.stream().anyMatch(prefix -> matchesPathSeparatedPrefix(path, prefix))) {
             LOG.debug("Quinoa is ignoring path (quarkus.quinoa.ignored-path-prefixes): " + path);
             return true;
         }

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaSPARoutingHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaSPARoutingHandler.java
@@ -30,8 +30,16 @@ class QuinoaSPARoutingHandler implements Handler<RoutingContext> {
         }
         String path = resolvePath(ctx);
         if (!Objects.equals(path, "/") && !isIgnored(path, config.ignoredPathPrefixes)) {
-            LOG.debugf("Quinoa is re-routing SPA request '%s' to '/'", ctx.normalizedPath());
-            ctx.reroute(ctx.mountPoint() != null ? ctx.mountPoint() : "/");
+            String mountPoint = ctx.mountPoint() != null ? ctx.mountPoint() : "/";
+            String routePath = ctx.currentRoute().getPath() != null ? ctx.currentRoute().getPath() : "/";
+            String target;
+            if (mountPoint.endsWith("/")) {
+                target = mountPoint.substring(0, mountPoint.length() - 1) + routePath;
+            } else {
+                target = mountPoint + routePath;
+            }
+            LOG.debugf("Quinoa is re-routing SPA request '%s' to '%s'", ctx.normalizedPath(), target);
+            ctx.reroute(target);
         } else {
             next(currentClassLoader, ctx);
         }


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Describe your changes

This is a back-port of #691 to the `2.3.x` branch.
Note that if the `quarkus.quinoa.ui-root-path=/foo` is set, then `http://localhost:8080/foo` redirects to `http://localhost:8080/foo/` to serve the `index.html` file in production mode.
This happens, because in production mode `io.vertx.ext.web.handler.StaticHandler` is used to serve files which already implements this behavior.

<!--  If your PR fixes an open issue then use Closes #31 -->
## Fixes Issue

Fixes #302
 
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--

[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done -->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
