### PR TITLE
[Fix/727] Change location for get angular application configuration

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/AngularFramework.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/AngularFramework.java
@@ -5,10 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
-import jakarta.json.Json;
-import jakarta.json.JsonException;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonReader;
+import jakarta.json.*;
 
 import io.quarkiverse.quinoa.deployment.config.PackageManagerCommandConfig;
 import io.quarkiverse.quinoa.deployment.config.QuinoaConfig;
@@ -32,12 +29,20 @@ public class AngularFramework extends GenericFramework {
         return new QuinoaConfigDelegate(super.override(originalConfig, packageJson, detectedDevScript, isCustomized)) {
             @Override
             public Optional<String> buildDir() {
-                // Angular builds a custom directory "dist/[appname]" or "dist/[appname]/browser" if it is build with application builder
-                final String applicationName = packageJson.map(p -> p.getString("name")).orElse("quinoa");
                 final JsonObject angularJson = readAngularJson(originalConfig);
-                final String builder = getBuilderUse(angularJson, applicationName);
-                String fullBuildDir = String.format("%s/%s", getDefaultBuildDir(), applicationName);
-                if (ANGULAR_DEVKIT_BUILD_ANGULAR_APPLICATION.equals(builder)) {
+                final JsonObject projectList = angularJson.getJsonObject("projects");
+                final JsonObject builder = projectList.values().stream()
+                        .map(JsonValue::asJsonObject)
+                        .filter(project -> "application".equals(project.getString("projectType")))
+                        .findFirst()
+                        .orElseThrow(() -> new RuntimeException(
+                                "Quinoa failed to determine which application must be started in the angular.json file."))
+                        .getJsonObject("architect")
+                        .getJsonObject("build");
+
+                final String builderName = builder.getString("builder");
+                String fullBuildDir = builder.getJsonObject("options").getString("outputPath");
+                if (ANGULAR_DEVKIT_BUILD_ANGULAR_APPLICATION.equals(builderName)) {
                     fullBuildDir = String.format("%s/browser", fullBuildDir);
                 }
                 return Optional.of(originalConfig.buildDir().orElse(fullBuildDir));
@@ -51,11 +56,6 @@ public class AngularFramework extends GenericFramework {
                 } catch (IOException | JsonException e) {
                     throw new RuntimeException("Quinoa failed to read the angular.json file. %s", e);
                 }
-            }
-
-            private static String getBuilderUse(JsonObject angularJson, String applicationName) {
-                return angularJson.getJsonObject("projects").getJsonObject(applicationName)
-                        .getJsonObject("architect").getJsonObject("build").getString("builder");
             }
 
             @Override

--- a/integration-tests/src/main/ui-angular-esbuild/package-lock.json
+++ b/integration-tests/src/main/ui-angular-esbuild/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "quinoa-app",
+  "name": "quinoa",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "quinoa-app",
+      "name": "quinoa",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^18.0.0",

--- a/integration-tests/src/main/ui-angular-esbuild/package.json
+++ b/integration-tests/src/main/ui-angular-esbuild/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "quinoa-app",
+  "name": "quinoa",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Describe your changes

I have changed the detection of angular configuration application. Before we used the package.json's name. Now we get the application available in angular.json file. If multiple applications exist in this configuration, an exception will be thrown. Users have to help quinoa to know which one must be build in this context.

<!--  If your PR fixes an open issue then use Closes #31 -->
## Fixes Issue
closes #721 
Fix #723 
 
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--

[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done -->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
