### PR TITLE
Next14 support

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/FrameworkType.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/FrameworkType.java
@@ -44,7 +44,7 @@ public enum FrameworkType {
     SOLID_START_LEGACY(Set.of("solid-start dev"), generic("dist", "dev", 3000)),
     SOLID_START(Set.of("vinxi dev"), generic(".output", "dev", 3000)),
     ASTRO(Set.of("astro dev"), generic("dist", "dev", 3000)),
-    NEXT(Set.of("next dev"), new NextFramework()),
+    NEXT(Set.of("next"), new NextFramework()),
     NUXT(Set.of("nuxt dev"), generic("dist", "dev", 3000)),
     ANGULAR(Set.of("ng serve"), new AngularFramework()),
     EMBER(Set.of("ember-cli serve"), generic("dist", "serve", 4200)),


### PR DESCRIPTION
 The new default next script from create-next-app

```js
"scripts": {
    "dev": "next",
    "build": "next build",
    "start": "next start"
  },
```

So we need to look for just "next"