### PR TITLE
fix: added check to check if package.json contains output

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/NextFramework.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/NextFramework.java
@@ -14,7 +14,7 @@ import io.quarkiverse.quinoa.deployment.config.delegate.QuinoaConfigDelegate;
 public class NextFramework extends GenericFramework {
 
     private static final Logger LOG = Logger.getLogger(NextFramework.class);
-    private static final String OUTPUT = "export";
+    private static final String EXPECTED_OUTPUT_VALUE = "export";
 
     public NextFramework() {
         super("out", "dev", 3000);
@@ -34,7 +34,7 @@ public class NextFramework extends GenericFramework {
                 }
 
                 String output = packageJson.get().getString("output", null);
-                if (!OUTPUT.equals(output)) {
+                if (!EXPECTED_OUTPUT_VALUE.equals(output)) {
                     LOG.warn(
                             "Make sure you define  \"output\": \"export \", in the package.json to make Next work with Quinoa.");
                 }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/NextFramework.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/NextFramework.java
@@ -32,8 +32,9 @@ public class NextFramework extends GenericFramework {
                     LOG.warn(
                             "Make sure you define  \"build\": \"next build \", in the package.json to make Next work with Quinoa.");
                 }
-                
-                if (!packageJson.get().containsKey("output") || !OUTPUT.equals(packageJson.get().getString("output"))) {
+
+                String output = packageJson.get().getString("output", null);
+                if (!OUTPUT.equals(output)) {
                     LOG.warn(
                             "Make sure you define  \"output\": \"export \", in the package.json to make Next work with Quinoa.");
                 }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/NextFramework.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/NextFramework.java
@@ -14,6 +14,7 @@ import io.quarkiverse.quinoa.deployment.config.delegate.QuinoaConfigDelegate;
 public class NextFramework extends GenericFramework {
 
     private static final Logger LOG = Logger.getLogger(NextFramework.class);
+    private static final String OUTPUT = "export";
 
     public NextFramework() {
         super("out", "dev", 3000);
@@ -31,8 +32,8 @@ public class NextFramework extends GenericFramework {
                     LOG.warn(
                             "Make sure you define  \"build\": \"next build \", in the package.json to make Next work with Quinoa.");
                 }
-                String output = packageJson.get().getString("output");
-                if (!"export".equals(output)) {
+                
+                if (!packageJson.get().containsKey("output") || !OUTPUT.equals(packageJson.get().getString("output"))) {
                     LOG.warn(
                             "Make sure you define  \"output\": \"export \", in the package.json to make Next work with Quinoa.");
                 }


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Describe your changes

This PR adds a check to ensure that if `package.json` doesn't contain an `output` field, we don't get a null pointer exception, but instead, get an appropriate warning.

Error in question:
```
[error]: Build step io.quarkiverse.quinoa.deployment.QuinoaProcessor#prepareQuinoaDirectory threw an exception: java.lang.NullPointerException: Cannot invoke "jakarta.json.JsonString.getString()" because the return value of "org.eclipse.parsson.JsonObjectBuilderImpl$JsonObjectImpl.getJsonString(String)" is null
[ERROR] 	at org.eclipse.parsson.JsonObjectBuilderImpl$JsonObjectImpl.getString(JsonObjectBuilderImpl.java:249)
[ERROR] 	at io.quarkiverse.quinoa.deployment.framework.override.NextFramework.override(NextFramework.java:34)
[ERROR] 	at io.quarkiverse.quinoa.deployment.framework.FrameworkType.overrideConfig(FrameworkType.java:91)
[ERROR] 	at io.quarkiverse.quinoa.deployment.QuinoaProcessor.prepareQuinoaDirectory(QuinoaProcessor.java:109)
[ERROR] 	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
[ERROR] 	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
[ERROR] 	at io.quarkus.builder.BuildContext.run(BuildContext.java:256)
[ERROR] 	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
[ERROR] 	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2516)
[ERROR] 	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2495)
[ERROR] 	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1521)
[ERROR] 	at java.base/java.lang.Thread.run(Thread.java:1570)
[ERROR] 	at org.jboss.threads.JBossThread.run(JBossThread.java:483)
```
 
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--

[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done -->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
