### PR TITLE
docs: added caution section for nextjs and warning

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/NextFramework.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/NextFramework.java
@@ -24,6 +24,8 @@ public class NextFramework extends GenericFramework {
     public QuinoaConfig override(QuinoaConfig delegate, Optional<JsonObject> packageJson,
             Optional<String> detectedDevScript,
             boolean isCustomized) {
+        LOG.warn("Next.js version 13 and above are not fully supported yet. Please make sure to use version 12 or below.");
+
         if (delegate.packageManagerCommand().build().orElse("???").equals("run build") && packageJson.isPresent()) {
             JsonObject scripts = packageJson.get().getJsonObject("scripts");
             if (scripts != null) {
@@ -40,6 +42,7 @@ public class NextFramework extends GenericFramework {
                 }
             }
         }
+
         return new QuinoaConfigDelegate(super.override(delegate, packageJson, detectedDevScript, isCustomized)) {
 
             @Override

--- a/docs/modules/ROOT/pages/web-frameworks.adoc
+++ b/docs/modules/ROOT/pages/web-frameworks.adoc
@@ -174,6 +174,9 @@ a|
 
 |===
 
+CAUTION: Next.js versions 13 and above are not fully supported due to several issues, including the lack of support for the `export` output. For example, dynamic routes are not supported for the App Router.
+https://github.com/vercel/next.js/discussions/55393[See Next.js issue 55393 for more information.]
+
 == Required Configuration
 
 [#angular-test-config]


### PR DESCRIPTION
 <!--  Describe your changes below that what did you made change -->
## Describe your changes

This PR adds a section to the web frameworks documentation about Next.js not being fully supported for versions 13 and above. It also adds a warning message when using Next.js.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--

[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done -->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
