### PR TITLE
buildDir calculation also supports outputPath being a JsonObject

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/quinoa/deployment/framework/override/AngularFrameworkTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/deployment/framework/override/AngularFrameworkTest.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.quinoa.deployment.framework.override;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class AngularFrameworkTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "builder-browser-output-str, dist/acme-frontend",
+            "builder-application-output-str, dist/acme-frontend/browser",
+            "builder-application-output-obj-no-browser, dist/acme-frontend/browser",
+            "builder-application-output-obj-browser, dist/acme-frontend/ui",
+    })
+    void testBuilderOutputPath(String jsonResource, String expectedBuildDir) {
+        // given
+        JsonObject givenBuilder = readTestJson(jsonResource);
+
+        // when
+        String actual = AngularFramework.getBuildDir(givenBuilder);
+
+        // then
+        assertThat(actual).isEqualTo(expectedBuildDir);
+    }
+
+    private JsonObject readTestJson(String jsonResource) {
+        ClassLoader classLoader = AngularFrameworkTest.class.getClassLoader();
+        InputStream jsonStream = classLoader.getResourceAsStream("frameworks/angular/" + jsonResource + ".json");
+        return Json.createReader(jsonStream).readObject();
+    }
+
+}

--- a/deployment/src/test/resources/frameworks/angular/builder-application-output-obj-browser.json
+++ b/deployment/src/test/resources/frameworks/angular/builder-application-output-obj-browser.json
@@ -1,0 +1,9 @@
+{
+  "builder": "@angular-devkit/build-angular:application",
+  "options": {
+    "outputPath": {
+      "base": "dist/acme-frontend",
+      "browser": "ui"
+    }
+  }
+}

--- a/deployment/src/test/resources/frameworks/angular/builder-application-output-obj-no-browser.json
+++ b/deployment/src/test/resources/frameworks/angular/builder-application-output-obj-no-browser.json
@@ -1,0 +1,8 @@
+{
+  "builder": "@angular-devkit/build-angular:application",
+  "options": {
+    "outputPath": {
+      "base": "dist/acme-frontend"
+    }
+  }
+}

--- a/deployment/src/test/resources/frameworks/angular/builder-application-output-str.json
+++ b/deployment/src/test/resources/frameworks/angular/builder-application-output-str.json
@@ -1,0 +1,6 @@
+{
+  "builder": "@angular-devkit/build-angular:application",
+  "options": {
+    "outputPath": "dist/acme-frontend"
+  }
+}

--- a/deployment/src/test/resources/frameworks/angular/builder-browser-output-str.json
+++ b/deployment/src/test/resources/frameworks/angular/builder-browser-output-str.json
@@ -1,0 +1,6 @@
+{
+  "builder": "@angular-devkit/build-angular:browser",
+  "options": {
+    "outputPath": "dist/acme-frontend"
+  }
+}


### PR DESCRIPTION
## Describe your changes
Since `outputPath` in `build` section of `angular.json` can be either [a String or an Object](https://angular.dev/reference/configs/workspace-config#output-path-configuration), existing `AngularFramework` was failing in the latter case.

Fixed that. Test cases cover all _schema-valid_ variants of `build` section of `angular.json`.

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
