### PR TITLE
Update documentation for vite port

### DIFF
--- a/docs/modules/ROOT/pages/web-frameworks.adoc
+++ b/docs/modules/ROOT/pages/web-frameworks.adoc
@@ -224,12 +224,10 @@ Configure `vite.config.ts` file with the following changes:
   export default defineConfig({
     // depending on your application, base can also be "/"
     base: '',
-    plugins: [react(), viteTsconfigPaths()],
+    plugins: [react()],
     server: {    
         // this ensures that the browser opens upon server start
-        open: true,
-        // this sets a default port to 3000, you can change this  
-        port: 3000, 
+        open: true
     },
 })
 ----


### PR DESCRIPTION
 It looks like the behaviour has got a bit out of sync with the docs. When using Vite, the docs say to set the Vite port to 3000, but actually, Quarkus detects Vite and looks on port 5173. If Vite is actually serving on port 3000, Quarkus can't find the web app and hangs starting. 

I was less sure about removing the https://www.npmjs.com/package/vite-tsconfig-paths plugin, but if I generated an app using `npm create vite@latest my-react-vite-app -- --template react`, listing that plugin caused a `ReferenceError: viteTsconfigPaths is not defined` error, and again the app wouldn't start. It seems safer to not list it than list it, since it's not always needed in the js case.

I also found the behaviour of popping up a browser window annoying, but since the right url is otherwise kind of hard to find, I left that bit. :)