### PR TITLE
docs: clarify Quinoa frontend packaging (refs #873)

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -93,6 +93,6 @@ $ quarkus build
 $ java -jar target/quarkus-app/quarkus-run.jar
 ----
 
-*It's done!* The web application is now built alongside Quarkus, dev-mode is available, and the generated files will be automatically copied to the right place and be served by Quinoa if you hit http://localhost:8080
+*It's done!* The web application is now built alongside Quarkus, dev-mode is available, and the generated files will be automatically copied to the build output directory and registered as Quarkus build-time generated resources. These files will be served by Quinoa if you hit http://localhost:8080
 
-WARNING: With Quinoa, you don't need to manually copy the files to `META-INF/resources`. Quinoa has its own system and will provide another Vert.x route for it. *If you have conflicting files with `META-INF/resources`, Quinoa will have priority over them.*
+WARNING: With Quinoa, you don't need to manually copy the files to `META-INF/resources`. Quinoa registers frontend build output as Quarkus build-time generated static resources and serves them through a dedicated Vert.x route. In production builds using the default fast-jar packaging, these files are packaged under `target/quarkus-app/quarkus/generated-bytecode.jar`. *If you have conflicting files with `META-INF/resources`, Quinoa will have priority over them.*


### PR DESCRIPTION
Clarifies in docs where Quinoa frontend build output is packaged in production builds.

Related to #873