### PR TITLE
Add pre-hook for Quarkus Ecosystem CI workflow

### DIFF
--- a/.github/workflows/hooks/pre-quarkus-ecosystem-ci.sh
+++ b/.github/workflows/hooks/pre-quarkus-ecosystem-ci.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#---------------------------------------------------
+# Hook invoked by the Quarkus Ecosystem CI workflow
+#---------------------------------------------------
+
+# Install pnpm
+npm install -g pnpm@~8.6.12
+
+# Install bun
+npm install -g bun
+
+# Ensure browsers are installed
+./current-repo/testing/../mvnw exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps chromium"


### PR DESCRIPTION
- Ensure critical dependencies, including `pnpm`, `bun`, and Playwright browser tooling, are installed
