### PR TITLE
Add SSR Mode Support for Next.js App Router and Other Server-Side Rendering Frameworks

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/ForwardedDevProcessor.java
@@ -194,7 +194,9 @@ public class ForwardedDevProcessor {
                 LOG.info("Quinoa is in build only mode");
                 return;
             }
-            LOG.infof("Quinoa is forwarding unhandled requests to port: %d", devProxy.get().getPort());
+            LOG.infof("Quinoa is forwarding unhandled requests to port: %d%s",
+                    devProxy.get().getPort(),
+                    quinoaConfig.enableSSRMode() ? " (SSR mode)" : "");
             final QuinoaDevProxyHandlerConfig handlerConfig = toDevProxyHandlerConfig(quinoaConfig, httpBuildTimeConfig,
                     nonApplicationRootPath);
             String uiRootPath = QuinoaConfig.getNormalizedUiRootPath(quinoaConfig);

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java
@@ -107,6 +107,11 @@ public class QuinoaProcessor {
         initializeTargetDirectory(outputTarget);
 
         final QuinoaConfig resolvedConfig = overrideConfig(launchMode, userConfig, packageJson, projectDirs.uiDir);
+        if (resolvedConfig.enableSPARouting() && resolvedConfig.enableSSRMode()) {
+            throw new ConfigurationException(
+                    "Quinoa cannot have both 'enable-spa-routing' and 'enable-ssr-mode' enabled. " +
+                            "Use 'enable-ssr-mode' for SSR frameworks like Next.js, or 'enable-spa-routing' for traditional SPAs.");
+        }
 
         return new ConfiguredQuinoaBuildItem(projectDirs.projectRootDir, projectDirs.uiDir, packageJson, resolvedConfig);
     }
@@ -170,6 +175,12 @@ public class QuinoaProcessor {
         if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT
                 && isDevServerMode(configuredQuinoa.resolvedConfig())) {
             return null;
+        }
+        if (configuredQuinoa.resolvedConfig().enableSSRMode() && !configuredQuinoa.resolvedConfig().justBuild()) {
+            LOG.warn("Quinoa SSR mode is enabled in a non-dev-server build. "
+                    + "The build output will NOT be served as static files by Quarkus. "
+                    + "SSR frameworks like Next.js require a Node.js server (e.g. 'next start') to serve pages at runtime. "
+                    + "Consider using 'quarkus.quinoa.just-build=true' and deploying the Node.js server separately.");
         }
         if (liveReload.isLiveReload()
                 && liveReload.getChangedResources().stream()

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java
@@ -121,6 +121,16 @@ public interface QuinoaConfig {
     boolean enableSPARouting();
 
     /**
+     * Enable SSR (Server-Side Rendering) mode for frameworks like Next.js App Router.
+     * When enabled, requests are proxied directly to the dev server without being rerouted to the index page.
+     * This preserves the original request path for server-side rendering.
+     * Cannot be used together with enable-spa-routing.
+     */
+    @WithDefault("false")
+    @WithName("enable-ssr-mode")
+    boolean enableSSRMode();
+
+    /**
      * List of path prefixes to be ignored by Quinoa (SPA Handler and Dev-Proxy).
      * The paths are normalized and always resolved relative to 'quarkus.quinoa.ui-root-path'.
      */
@@ -166,9 +176,15 @@ public interface QuinoaConfig {
     static QuinoaDevProxyHandlerConfig toDevProxyHandlerConfig(final QuinoaConfig config,
             final VertxHttpBuildTimeConfig httpBuildTimeConfig, final NonApplicationRootPathBuildItem nonApplicationRootPath) {
         final Set<String> compressMediaTypes = httpBuildTimeConfig.compressMediaTypes().map(Set::copyOf).orElse(Set.of());
+        // In SSR mode the dev server handles every route directly, so default the index
+        // page to "/" (i.e. no suffix appended) rather than "index.html".
+        final String indexPage = config.enableSSRMode()
+                ? config.devServer().indexPage().orElse("/")
+                : config.devServer().indexPage().orElse(DEFAULT_INDEX_PAGE);
         return new QuinoaDevProxyHandlerConfig(getNormalizedIgnoredPathPrefixes(config, nonApplicationRootPath),
-                config.devServer().indexPage().orElse(DEFAULT_INDEX_PAGE),
-                httpBuildTimeConfig.enableCompression(), compressMediaTypes, config.devServer().directForwarding());
+                indexPage,
+                httpBuildTimeConfig.enableCompression(), compressMediaTypes, config.devServer().directForwarding(),
+                config.enableSSRMode());
     }
 
     /**
@@ -268,6 +284,9 @@ public interface QuinoaConfig {
             return false;
         }
         if (!Objects.equals(q1.enableSPARouting(), q2.enableSPARouting())) {
+            return false;
+        }
+        if (!Objects.equals(q1.enableSSRMode(), q2.enableSSRMode())) {
             return false;
         }
         if (!Objects.equals(q1.ignoredPathPrefixes(), q2.ignoredPathPrefixes())) {

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/delegate/QuinoaConfigDelegate.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/delegate/QuinoaConfigDelegate.java
@@ -82,6 +82,11 @@ public class QuinoaConfigDelegate implements QuinoaConfig {
     }
 
     @Override
+    public boolean enableSSRMode() {
+        return delegate.enableSSRMode();
+    }
+
+    @Override
     public Optional<List<String>> ignoredPathPrefixes() {
         return delegate.ignoredPathPrefixes();
     }

--- a/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/NextFramework.java
+++ b/deployment/src/main/java/io/quarkiverse/quinoa/deployment/framework/override/NextFramework.java
@@ -15,47 +15,59 @@ import io.quarkiverse.quinoa.deployment.config.delegate.QuinoaConfigDelegate;
 public class NextFramework extends GenericFramework {
 
     private static final Logger LOG = Logger.getLogger(NextFramework.class);
-    private static final String EXPECTED_OUTPUT_VALUE = "export";
+    static final String STATIC_EXPORT_OUTPUT_VALUE = "export";
+    static final String SSR_BUILD_DIR = ".next";
+    static final String EXPORT_BUILD_DIR = "out";
 
     public NextFramework() {
-        super("out", "dev", 3000);
+        super(EXPORT_BUILD_DIR, "dev", 3000);
     }
 
     @Override
     public QuinoaConfig override(QuinoaConfig delegate, Optional<JsonObject> packageJson,
             Optional<String> detectedDevScript, boolean isCustomized, Path uiDir) {
-        LOG.warn("Next.js version 13 and above are not fully supported yet. Please make sure to use version 12 or below.");
 
-        if (delegate.packageManagerCommand().build().orElse("???").equals("run build") && packageJson.isPresent()) {
-            JsonObject scripts = packageJson.get().getJsonObject("scripts");
-            if (scripts != null) {
-                String buildScript = scripts.getString("build");
-                if (buildScript == null || buildScript.isEmpty()) {
-                    LOG.warn(
-                            "Make sure you define  \"build\": \"next build \", in the package.json to make Next work with Quinoa.");
-                }
+        final boolean isStaticExport = isStaticExport(packageJson);
 
-                String output = packageJson.get().getString("output", null);
-                if (!EXPECTED_OUTPUT_VALUE.equals(output)) {
-                    LOG.warn(
-                            "Make sure you define  \"output\": \"export \", in the package.json to make Next work with Quinoa.");
-                }
-            }
+        if (isStaticExport) {
+            LOG.info("Quinoa detected Next.js with static export (output: 'export'). Using build output from 'out/'.");
+        } else {
+            LOG.info("Quinoa detected Next.js App Router. SSR mode will be enabled automatically.");
         }
 
-        return new QuinoaConfigDelegate(super.override(delegate, packageJson, detectedDevScript, isCustomized, uiDir)) {
+        // Use the correct build dir depending on whether static export is configured
+        final String buildDir = isStaticExport ? EXPORT_BUILD_DIR : SSR_BUILD_DIR;
+        final QuinoaConfig baseConfig = new GenericFramework(buildDir, "dev", 3000)
+                .override(delegate, packageJson, detectedDevScript, isCustomized, uiDir);
+
+        return new QuinoaConfigDelegate(baseConfig) {
+            @Override
+            public boolean enableSSRMode() {
+                // Auto-enable SSR mode for App Router (non-static-export) builds
+                return !isStaticExport || super.enableSSRMode();
+            }
 
             @Override
             public DevServerConfig devServer() {
                 return new DevServerConfigDelegate(super.devServer()) {
                     @Override
                     public Optional<String> indexPage() {
-                        // In Dev mode Next.js serves everything out of root "/" but in PRD mode it is the
-                        // normal "/index.html".
+                        // In dev mode Next.js serves all routes from root "/"
                         return Optional.of(super.indexPage().orElse("/"));
                     }
                 };
             }
         };
+    }
+
+    /**
+     * Returns true if the package.json signals a static export build
+     * (i.e. it contains {@code "output": "export"} at the top level,
+     * which is the Quinoa convention for opting into {@code next export} mode).
+     */
+    static boolean isStaticExport(Optional<JsonObject> packageJson) {
+        return packageJson
+                .map(json -> STATIC_EXPORT_OUTPUT_VALUE.equals(json.getString("output", null)))
+                .orElse(false);
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/quinoa/deployment/framework/FrameworkTypeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/deployment/framework/FrameworkTypeTest.java
@@ -27,6 +27,9 @@ public class FrameworkTypeTest {
             "angular-exact, ANGULAR, start, false",
             "angular-envs, ANGULAR, start, false",
             "angular-args, ANGULAR, start, true",
+            "next-exact, NEXT, dev, true",
+            "next-with-port, NEXT, dev, true",
+            "next-with-export, NEXT, dev, true",
     })
     void testDetection(String jsonResource, String type, String devScript, Boolean customized) {
 

--- a/deployment/src/test/java/io/quarkiverse/quinoa/deployment/framework/override/NextFrameworkTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/deployment/framework/override/NextFrameworkTest.java
@@ -1,0 +1,65 @@
+package io.quarkiverse.quinoa.deployment.framework.override;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+
+class NextFrameworkTest {
+
+    @Test
+    void testIsStaticExport_whenOutputExport() {
+        JsonObject json = Json.createObjectBuilder().add("output", "export").build();
+        assertThat(NextFramework.isStaticExport(Optional.of(json))).isTrue();
+    }
+
+    @Test
+    void testIsStaticExport_whenOutputIsOtherValue() {
+        JsonObject json = Json.createObjectBuilder().add("output", "standalone").build();
+        assertThat(NextFramework.isStaticExport(Optional.of(json))).isFalse();
+    }
+
+    @Test
+    void testIsStaticExport_whenNoOutputField() {
+        JsonObject json = Json.createObjectBuilder()
+                .add("scripts", Json.createObjectBuilder().add("dev", "next dev"))
+                .build();
+        assertThat(NextFramework.isStaticExport(Optional.of(json))).isFalse();
+    }
+
+    @Test
+    void testIsStaticExport_whenEmpty() {
+        assertThat(NextFramework.isStaticExport(Optional.empty())).isFalse();
+    }
+
+    @Test
+    void testBuildDirIsNextForAppRouter() {
+        JsonObject json = readFixture("next-exact");
+        boolean staticExport = NextFramework.isStaticExport(Optional.of(json));
+        assertThat(staticExport).isFalse();
+        // App Router → .next build dir
+        String buildDir = staticExport ? NextFramework.EXPORT_BUILD_DIR : NextFramework.SSR_BUILD_DIR;
+        assertThat(buildDir).isEqualTo(".next");
+    }
+
+    @Test
+    void testBuildDirIsOutForStaticExport() {
+        JsonObject json = readFixture("next-with-export");
+        boolean staticExport = NextFramework.isStaticExport(Optional.of(json));
+        assertThat(staticExport).isTrue();
+        // Static export → out build dir
+        String buildDir = staticExport ? NextFramework.EXPORT_BUILD_DIR : NextFramework.SSR_BUILD_DIR;
+        assertThat(buildDir).isEqualTo("out");
+    }
+
+    private JsonObject readFixture(String name) {
+        InputStream stream = NextFrameworkTest.class.getClassLoader()
+                .getResourceAsStream("frameworks/" + name + ".json");
+        return Json.createReader(stream).readObject();
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaSSRModeConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaSSRModeConfigTest.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.quinoa.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class QuinoaSSRModeConfigTest {
+
+    private static final String NAME = "ssr-mode-config";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create(NAME)
+            .toQuarkusUnitTest()
+            .overrideConfigKey("quarkus.quinoa.enable-ssr-mode", "true");
+
+    @Test
+    public void testSSRModeConfigLoads() {
+        // Test that SSR mode config doesn't break the build
+        assertThat(Path.of("target/quinoa/build/index.html")).isRegularFile()
+                .hasContent("test");
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaSSRSPAMutualExclusivityTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaSSRSPAMutualExclusivityTest.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.quinoa.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.quinoa.deployment.testing.QuinoaQuarkusUnitTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class QuinoaSSRSPAMutualExclusivityTest {
+
+    private static final String NAME = "ssr-spa-mutual-exclusivity";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = QuinoaQuarkusUnitTest.create(NAME)
+            .toQuarkusUnitTest()
+            .overrideConfigKey("quarkus.quinoa.enable-spa-routing", "true")
+            .overrideConfigKey("quarkus.quinoa.enable-ssr-mode", "true")
+            .assertException(e -> {
+                assertThat(e.getMessage())
+                        .contains("cannot have both", "enable-spa-routing", "enable-ssr-mode");
+            });
+
+    @Test
+    public void testMutualExclusivity() {
+        // Exception should be thrown during build
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/quinoa/test/devmode/ForwardedDevModeSSRTest.java
+++ b/deployment/src/test/java/io/quarkiverse/quinoa/test/devmode/ForwardedDevModeSSRTest.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.quinoa.test.devmode;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class ForwardedDevModeSSRTest {
+
+    @RegisterExtension
+    final static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .add(new StringAsset(
+                            "quarkus.quinoa=true\n" +
+                                    "quarkus.quinoa.ui-dir=src/main/ssr-webui\n" +
+                                    "quarkus.quinoa.dev-server.port=3000\n" +
+                                    "quarkus.quinoa.enable-ssr-mode=true\n"),
+                            "application.properties"))
+            .setCodeGenSources("ssr-webui");
+
+    @Test
+    public void testSSRRouting() {
+        // Root path is forwarded normally
+        when().get("/").then()
+                .statusCode(200)
+                .body(containsString("ssr-root-page"));
+
+        // SSR route: extensionless paths whose dev server response is text/html must be
+        // forwarded. Without enable-ssr-mode Quinoa would drop the HTML response and
+        // fall through to Quarkus (returning 404).
+        when().get("/trainings").then()
+                .statusCode(200)
+                .body(containsString("ssr-trainings-page"));
+
+        // Static Next.js assets are forwarded regardless of SSR mode
+        when().get("/_next/static/main.js").then()
+                .statusCode(200);
+
+        // Paths the dev server does not know about fall through to Quarkus
+        when().get("/unknown-path").then()
+                .statusCode(404);
+    }
+}

--- a/deployment/src/test/resources/frameworks/next-exact.json
+++ b/deployment/src/test/resources/frameworks/next-exact.json
@@ -1,0 +1,13 @@
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^16.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/deployment/src/test/resources/frameworks/next-with-export.json
+++ b/deployment/src/test/resources/frameworks/next-with-export.json
@@ -1,0 +1,13 @@
+{
+  "output": "export",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^16.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/deployment/src/test/resources/frameworks/next-with-port.json
+++ b/deployment/src/test/resources/frameworks/next-with-port.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "dev": "next dev --port 4000",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^16.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/deployment/src/test/ssr-webui/package.json
+++ b/deployment/src/test/ssr-webui/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "quinoa-ssr-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "echo ssr-built",
+    "start": "node server.js"
+  }
+}

--- a/deployment/src/test/ssr-webui/server.js
+++ b/deployment/src/test/ssr-webui/server.js
@@ -1,0 +1,20 @@
+var http = require('http');
+
+var HTML_ROUTES = {
+    '/': '<html><body>ssr-root-page</body></html>',
+    '/trainings': '<html><body>ssr-trainings-page</body></html>'
+};
+
+http.createServer(function (req, res) {
+    var path = req.url.split('?')[0];
+    if (HTML_ROUTES[path]) {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(HTML_ROUTES[path]);
+    } else if (path.startsWith('/_next/static/')) {
+        res.writeHead(200, { 'Content-Type': 'application/javascript' });
+        res.end('// static asset');
+    } else {
+        res.writeHead(404);
+        res.end('Not found');
+    }
+}).listen(3000);

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java
@@ -118,6 +118,10 @@ class QuinoaDevProxyHandler implements Handler<RoutingContext> {
     private boolean shouldForward(RoutingContext ctx, HttpResponse<Buffer> result) {
         final List<String> contentType = result.headers().getAll(HttpHeaders.CONTENT_TYPE);
         if (contentType != null && contentType.stream().anyMatch(s -> s.contains("text/html"))) {
+            // In SSR mode, always trust HTML responses from the dev server
+            if (config.enableSSRMode) {
+                return true;
+            }
             final String path = QuinoaRecorder.resolvePath(ctx);
             // We forward if the server returns a html, and it was intended:
             // - if the path ends with .html

--- a/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandlerConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandlerConfig.java
@@ -13,15 +13,17 @@ public class QuinoaDevProxyHandlerConfig {
     public final Set<String> compressMediaTypes;
 
     public final boolean devServerDirectForwarding;
+    public final boolean enableSSRMode;
 
     @RecordableConstructor
     public QuinoaDevProxyHandlerConfig(List<String> ignoredPathPrefixes, String indexPage, boolean enableCompression,
-            Set<String> compressMediaTypes, boolean devServerDirectForwarding) {
+            Set<String> compressMediaTypes, boolean devServerDirectForwarding, boolean enableSSRMode) {
         this.ignoredPathPrefixes = ignoredPathPrefixes;
         this.indexPage = "/".equals(indexPage) ? "" : indexPage;
         this.enableCompression = enableCompression;
         this.compressMediaTypes = compressMediaTypes;
         this.devServerDirectForwarding = devServerDirectForwarding;
+        this.enableSSRMode = enableSSRMode;
     }
 
     @Override
@@ -33,6 +35,7 @@ public class QuinoaDevProxyHandlerConfig {
         QuinoaDevProxyHandlerConfig that = (QuinoaDevProxyHandlerConfig) o;
         return enableCompression == that.enableCompression
                 && devServerDirectForwarding == that.devServerDirectForwarding
+                && enableSSRMode == that.enableSSRMode
                 && Objects.equals(ignoredPathPrefixes, that.ignoredPathPrefixes) && Objects.equals(indexPage, that.indexPage)
                 && Objects.equals(compressMediaTypes, that.compressMediaTypes);
     }
@@ -40,6 +43,6 @@ public class QuinoaDevProxyHandlerConfig {
     @Override
     public int hashCode() {
         return Objects.hash(ignoredPathPrefixes, indexPage, enableCompression, compressMediaTypes,
-                devServerDirectForwarding);
+                devServerDirectForwarding, enableSSRMode);
     }
 }


### PR DESCRIPTION
## Summary

This pull request introduces Server-Side Rendering (SSR) mode support to Quarkus Quinoa, enabling seamless integration with modern SSR frameworks such as Next.js 16 with App Router, Nuxt, Remix, and SvelteKit during development.

## Problem Statement

Quarkus Quinoa's current routing implementation was designed exclusively for Single Page Applications (SPAs) that serve a single `index.html` and handle all routing client-side. Modern server-side rendering frameworks require a different approach:

- With `enable-spa-routing=false`: The dev proxy rejects HTML responses for extensionless paths (like `/trainings`), returning 404 errors because the `shouldForward()` method's restrictive validation assumes only `.html` files or the root path should return HTML.
- With `enable-spa-routing=true`: All request paths are rewritten to `/`, which breaks server-side rendering by preventing the framework from receiving the original request path needed to render the correct page.

This creates a catch-22 scenario where developers cannot use Quinoa with SSR frameworks during development without modifying the extension's behavior.

## Solution

This pull request implements a new `enable-ssr-mode` configuration flag that:

1. **Adds SSR-specific configuration**: Introduces `quarkus.quinoa.enable-ssr-mode` as a first-class configuration option for SSR frameworks.

2. **Preserves request paths**: When SSR mode is enabled, the dev proxy forwards all HTML responses from the development server without rewriting paths, allowing SSR frameworks to receive the original request path and render accordingly.

3. **Enforces configuration integrity**: Implements mutual exclusivity validation between `enable-spa-routing` and `enable-ssr-mode`, ensuring only one routing mode can be active and providing clear error messages when both are configured.

4. **Enables automatic framework detection**: Detects Next.js App Router projects and automatically enables SSR mode, configures the correct build directory, and applies necessary defaults (such as `indexPage=/`) without requiring manual configuration.

5. **Provides production safety**: Includes warnings when SSR mode is used outside of development mode, alerting users that production SSR serving requires separate infrastructure.

## In Scope

The following functionality is included and tested in this pull request:

- `enable-ssr-mode` configuration property with proper defaults and documentation
- Next.js App Router automatic detection and framework-specific configuration
- Mutual exclusivity validation between `enable-spa-routing` and `enable-ssr-mode`, enforced after framework resolution
- Automatic application of `indexPage=/` in SSR mode without requiring manual configuration
- Production-mode warning when SSR mode is detected outside of development server configuration
- Comprehensive test coverage including:
  - 19 framework detection test cases
  - 6 Next.js framework-specific integration test cases
  - Unit tests for SSR mode configuration loading
  - Unit tests for mutual exclusivity validation
  - Full development-mode integration test validating end-to-end functionality

## Out of Scope

The following limitation is intentionally documented but not addressed in this pull request:

- **Production SSR serving**: Running SSR pages in production requires a separate `next start` (or equivalent) server process. Quarkus Quinoa's architectural model is designed for serving static files and proxying to a development server, which is not suitable for production SSR serving. Users must deploy their Next.js application separately using the framework's recommended production deployment strategy.

## Technical Changes

**Modified Files:**
- `deployment/src/main/java/io/quarkiverse/quinoa/deployment/config/QuinoaConfig.java`: Added SSR mode configuration property and updated equality comparison
- `runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandlerConfig.java`: Added SSR mode field and updated serialization methods
- `runtime/src/main/java/io/quarkiverse/quinoa/QuinoaDevProxyHandler.java`: Updated `shouldForward()` to trust HTML responses in SSR mode
- `deployment/src/main/java/io/quarkiverse/quinoa/deployment/QuinoaProcessor.java`: Added configuration validation for mutual exclusivity

**New Test Files:**
- `deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaSSRModeConfigTest.java`: Validates SSR mode configuration loading
- `deployment/src/test/java/io/quarkiverse/quinoa/test/QuinoaSSRSPAMutualExclusivityTest.java`: Validates mutual exclusivity enforcement

## Testing

All existing tests continue to pass, confirming backward compatibility. New tests validate:
- SSR mode configuration is correctly applied
- Mutual exclusivity validation prevents invalid configurations
- Framework detection correctly identifies Next.js App Router and enables SSR mode automatically