### PR TITLE
docs: remove unnecessary include from nav.adoc

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,3 @@
-include::./includes/attributes.adoc[]
-:config-file: application.properties
-
 * xref:index.adoc[Getting started]
 * xref:main-concepts.adoc[Main Concepts]
 * xref:web-frameworks.adoc[Web Frameworks]


### PR DESCRIPTION
## Summary
- Fix Antora build errors for missing include files in nav.adoc:
  - `target of include not found: ./includes/attributes.adoc`
  - `target of include not found: ./_includes/attributes.adoc`

These errors appear during the quarkiverse-docs Antora build.

### Root Cause

`nav.adoc` is located at `docs/modules/ROOT/nav.adoc` and contained `include::./_includes/attributes.adoc[]` on line 1. While `_includes/attributes.adoc` exists inside the `pages/` directory (`docs/modules/ROOT/pages/_includes/attributes.adoc`), it does not exist at the ROOT module level where `nav.adoc` lives. The relative path resolves incorrectly for nav files processed by Antora.

### Fix

Removed the `include::./_includes/attributes.adoc[]` directive and the unused `:config-file:` attribute from `nav.adoc`. Navigation files only contain `xref` entries and do not need these attributes.