### PR TITLE
Fix ecosystem CI by installing pnpm and bun

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+# Install package managers needed by lockfile detection tests
+npm install -g pnpm
+npm install -g bun
+
+# update the versions
+mvn -nsu --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=quarkus.version -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
+mvn -nsu --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
+
+# run the tests
+mvn -nsu --settings .github/quarkus-ecosystem-maven-settings.xml -B clean install -Dnative -Dquarkus.native.container-build=true --fail-at-end -e


### PR DESCRIPTION
## Summary
- Add a custom `.github/quarkus-ecosystem-test` script that installs `pnpm` and `bun` before running tests
- The lockfile detection tests (`QuinoaPackageManagerLockfileDetectBunTest`, `QuinoaPackageManagerLockfileDetectPNPMTest`) require these tools but `ubuntu-latest` runners no longer include them
- The regular `build.yml` already installs them, but the ecosystem CI uses a reusable workflow that doesn't